### PR TITLE
Diagnostic viz

### DIFF
--- a/celavi/__main__.py
+++ b/celavi/__main__.py
@@ -118,6 +118,7 @@ costgraph_csv_filename = os.path.join(args.data, 'inputs', 'netw.csv')
 
 os.chdir(subfolder_dict['lci_folder'])
 from celavi.des import Context
+from celavi.diagnostic_viz import DiagnosticViz
 
 
 # Note that the step_cost file must be updated (or programmatically generated)
@@ -275,23 +276,5 @@ print('FINISHED RUN at %d s' % np.round(time.time() - time0),
       flush=True)
 
 # Plot the cumulative count levels of the inventories
-count_facility_inventory_items = list(count_facility_inventories.items())
-nrows = 5
-ncols = ceil(len(count_facility_inventory_items) / nrows)
-fig, axs = plt.subplots(nrows=nrows, ncols=ncols, figsize=(10, 10))
-plt.tight_layout()
-for i in range(len(count_facility_inventory_items)):
-    subplot_col = i // nrows
-    subplot_row = i % nrows
-    ax = axs[subplot_row][subplot_col]
-    facility_name, facility = count_facility_inventory_items[i]
-    cum_hist_blade = facility.cumulative_history["blade"]
-    ax.set_title(facility_name)
-    ax.plot(range(len(cum_hist_blade)), cum_hist_blade)
-    ax.set_ylabel("count")
-plot_output_path = os.path.join(subfolder_dict['outputs_folder'], 'blade_counts.png')
-plt.savefig(plot_output_path)
-
-pickle.dump(count_facility_inventory_items, open('graph_context_count_facility.obj', 'wb'))
-
-
+diagnostic_viz = DiagnosticViz(context, subfolder_dict['outputs_folder'])
+diagnostic_viz.generate_blade_count_plots()

--- a/celavi/diagnostic_viz.py
+++ b/celavi/diagnostic_viz.py
@@ -14,42 +14,89 @@ class DiagnosticViz:
     """
 
     def __init__(self, context: Context, output_folder_path: str):
+        """
+        Parameters
+        ----------
+        context: Context
+            The context that executed the simulation for diagnostic plots.
+
+        output_folder_path: str
+            The folder where the plots will show up.
+        """
         self.context = context
         self.cumulative_histories = None
         self.output_folder_path = output_folder_path
 
     def gather_cumulative_histories(self) -> pd.DataFrame:
+        """
+        This gathers the cumulative histories in a way that they can be plotted
+
+        Returns
+        -------
+        pd.DataFrame
+            A dataframe with the cumulative histories gathered together.
+        """
         cumulative_histories = []
 
         for facility, inventory in self.context.count_facility_inventories.items():
             cumulative_history = inventory.cumulative_history
             cumulative_history = cumulative_history.reset_index()
-            cumulative_history.rename(columns={'index': 'timestep'}, inplace=True)
+            cumulative_history.rename(columns={"index": "timestep"}, inplace=True)
             facility_type, facility_id = facility.split("_")
-            cumulative_history['facility_type'] = facility_type
-            cumulative_history['facility_id'] = facility_id
-            cumulative_history['year'] = (cumulative_history['timestep'] / 12) + 2000
-            cumulative_history['year_ceil'] = np.ceil(cumulative_history['year'])
+            cumulative_history["facility_type"] = facility_type
+            cumulative_history["facility_id"] = facility_id
+            cumulative_history["year"] = (cumulative_history["timestep"] / 12) + 2000
+            cumulative_history["year_ceil"] = np.ceil(cumulative_history["year"])
             cumulative_histories.append(cumulative_history)
 
         gathered = pd.concat(cumulative_histories)
 
-        blades_only = gathered.drop(columns=['nacelle', 'tower', 'foundation'])
-        blades_only.rename(columns={'blade': 'blade_count'}, inplace=True)
+        blades_only = gathered.drop(columns=["nacelle", "tower", "foundation"])
+        blades_only.rename(columns={"blade": "blade_count"}, inplace=True)
 
         return blades_only
 
     def generate_blade_count_plots(self):
+        """
+        Generate the blade count history plots
+        """
         cumulative_histories = self.gather_cumulative_histories()
-        blade_counts = cumulative_histories.loc[:, ['year', 'blade_count', 'facility_type']].groupby(
-            ['year', 'facility_type']).sum().reset_index()
-        fig = px.line(blade_counts, x='year', y='blade_count', facet_col='facility_type', title='Blade Counts',
-                      facet_col_wrap=2, width=1000, height=1500)
-        facet_plots_filename = os.path.join(self.output_folder_path, "blade_count_facets.png")
+        blade_counts = (
+            cumulative_histories.loc[:, ["year", "blade_count", "facility_type"]]
+            .groupby(["year", "facility_type"])
+            .sum()
+            .reset_index()
+        )
+        fig = px.line(
+            blade_counts,
+            x="year",
+            y="blade_count",
+            facet_col="facility_type",
+            title="Blade Counts",
+            facet_col_wrap=2,
+            width=1000,
+            height=1500,
+        )
+        facet_plots_filename = os.path.join(
+            self.output_folder_path, "blade_count_facets.png"
+        )
         fig.write_image(facet_plots_filename)
-        blade_counts = cumulative_histories.loc[:, ['year', 'blade_count', 'facility_type']].groupby(
-            ['year', 'facility_type']).sum().reset_index()
-        fig = px.line(blade_counts, x='year', y='blade_count', color='facility_type', title='Blade Counts', width=1000,
-                      height=500)
-        one_plot_filename = os.path.join(self.output_folder_path, "blade_count_single.png")
+        blade_counts = (
+            cumulative_histories.loc[:, ["year", "blade_count", "facility_type"]]
+            .groupby(["year", "facility_type"])
+            .sum()
+            .reset_index()
+        )
+        fig = px.line(
+            blade_counts,
+            x="year",
+            y="blade_count",
+            color="facility_type",
+            title="Blade Counts",
+            width=1000,
+            height=500,
+        )
+        one_plot_filename = os.path.join(
+            self.output_folder_path, "blade_count_single.png"
+        )
         fig.write_image(one_plot_filename)

--- a/celavi/diagnostic_viz.py
+++ b/celavi/diagnostic_viz.py
@@ -1,0 +1,55 @@
+import os
+
+import pandas as pd
+import numpy as np
+import plotly.express as px
+
+from .des import Context
+
+
+class DiagnosticViz:
+    """
+    This class creates diagnostic visualizations from a context when after the
+    model run has been executed.
+    """
+
+    def __init__(self, context: Context, output_folder_path: str):
+        self.context = context
+        self.cumulative_histories = None
+        self.output_folder_path = output_folder_path
+
+    def gather_cumulative_histories(self) -> pd.DataFrame:
+        cumulative_histories = []
+
+        for facility, inventory in self.context.count_facility_inventories.items():
+            cumulative_history = inventory.cumulative_history
+            cumulative_history = cumulative_history.reset_index()
+            cumulative_history.rename(columns={'index': 'timestep'}, inplace=True)
+            facility_type, facility_id = facility.split("_")
+            cumulative_history['facility_type'] = facility_type
+            cumulative_history['facility_id'] = facility_id
+            cumulative_history['year'] = (cumulative_history['timestep'] / 12) + 2000
+            cumulative_history['year_ceil'] = np.ceil(cumulative_history['year'])
+            cumulative_histories.append(cumulative_history)
+
+        gathered = pd.concat(cumulative_histories)
+
+        blades_only = gathered.drop(columns=['nacelle', 'tower', 'foundation'])
+        blades_only.rename(columns={'blade': 'blade_count'}, inplace=True)
+
+        return blades_only
+
+    def generate_blade_count_plots(self):
+        cumulative_histories = self.gather_cumulative_histories()
+        blade_counts = cumulative_histories.loc[:, ['year', 'blade_count', 'facility_type']].groupby(
+            ['year', 'facility_type']).sum().reset_index()
+        fig = px.line(blade_counts, x='year', y='blade_count', facet_col='facility_type', title='Blade Counts',
+                      facet_col_wrap=2, width=1000, height=1500)
+        facet_plots_filename = os.path.join(self.output_folder_path, "blade_count_facets.png")
+        fig.write_image(facet_plots_filename)
+        blade_counts = cumulative_histories.loc[:, ['year', 'blade_count', 'facility_type']].groupby(
+            ['year', 'facility_type']).sum().reset_index()
+        fig = px.line(blade_counts, x='year', y='blade_count', color='facility_type', title='Blade Counts', width=1000,
+                      height=500)
+        one_plot_filename = os.path.join(self.output_folder_path, "blade_count_single.png")
+        fig.write_image(one_plot_filename)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ setuptools.setup(
 	    "networkx-query",
         "olca-ipc",
         "pyutilib",
-        "joblib"
+        "joblib",
+        "plotly",
+        "kaleido"
     ]
 )


### PR DESCRIPTION
This makes diagnostic visualization plots, to be placed into the output folder of the of the output files, at the end of each run.

You will need to do a `pip install -e .` again to ensure that `plotly` and `kaleido` are in the dependencies to allow the plotting to work.

When working with the tiny dataset, you will get plots similar to the following:

![blade_count_single](https://user-images.githubusercontent.com/2609896/132737081-f6ef193a-45ad-4f37-896d-a23b3b46076e.png)

![blade_count_facets](https://user-images.githubusercontent.com/2609896/132737044-ae4ae9b4-4c1f-48b1-b84e-7efaae6e7357.png)

The plots are in the `outputs/` folder of the outputs folder structure.