### PR TITLE
Refine the filtering by state functionality for the locations and routes

### DIFF
--- a/celavi/__main__.py
+++ b/celavi/__main__.py
@@ -8,7 +8,7 @@ import pandas as pd
 from celavi.routing import Router
 from celavi.costgraph import CostGraph
 from celavi.compute_locations import ComputeLocations
-from celavi.data_filtering import data_filter
+from celavi.data_filtering import filter_locations, filter_routes
 import yaml
 
 parser = argparse.ArgumentParser(description='Execute CELAVI model')
@@ -192,17 +192,29 @@ if generate_step_costs:
         index=False
     )
 
+if use_computed_routes:
+    routes = routes_computed_filename
+else:
+    routes = routes_custom_filename
+
 # Data filtering for states
 states_to_filter = scenario_params.get('states_to_filter', [])
 if enable_data_filtering:
     if len(states_to_filter) == 0:
         print('Cannot filter data; no state list provided', flush=True)
     else:
-        print(f'Filtering: {states_to_filter}',
+        print(f'Filtering locations: {states_to_filter}',
               flush=True)
-        data_filter(locations_computed_filename,
-                    turbine_data_filename,
-                    states_to_filter)
+        filter_locations(locations_computed_filename,
+                         turbine_data_filename,
+                         states_to_filter)
+    # if the data is being filtered and a new routes file is NOT being
+    # generated, then the existing routes file must also be filtered
+    if ~run_routes:
+        print(f'Filtering routes: {states_to_filter}',
+              flush=True)
+        filter_routes(locations_computed_filename,
+                      routes)
 
 if run_routes:
     routes_computed = Router.get_all_routes(
@@ -213,10 +225,6 @@ if run_routes:
         routing_output_folder=subfolder_dict['routing_output_folder'],
         preprocessing_output_folder=subfolder_dict['preprocessing_output_folder'])
 
-if use_computed_routes:
-    routes = routes_computed_filename
-else:
-    routes = routes_custom_filename
 
 avgblade = pd.read_csv(avg_blade_masses_filename)
 

--- a/celavi/data_filtering.py
+++ b/celavi/data_filtering.py
@@ -2,7 +2,7 @@ import pandas as pd
 
 
 
-def data_filter(loc_file_name,num_of_turbines_filename,states):
+def filter_locations(loc_file_name,num_of_turbines_filename,states):
 
         locations = pd.read_csv(loc_file_name)
         
@@ -17,3 +17,20 @@ def data_filter(loc_file_name,num_of_turbines_filename,states):
         number_of_turbines = pd.read_csv(num_of_turbines_filename)
         number_of_turbines_filtered = number_of_turbines[number_of_turbines['facility_id'].isin(facility_id_included)]
         number_of_turbines_filtered.to_csv(num_of_turbines_filename)
+
+
+def filter_routes(locations_filename, routes_filename):
+        """
+
+        """
+
+        facility_id_included = list(
+                pd.read_csv(locations_filename).facility_id.unique()
+        )
+
+        routes = pd.read_csv(routes_filename)
+
+        routes_filtered = routes[(routes.source_facility_id.isin(facility_id_included)) &
+                                 (routes.destination_facility_id.isin(facility_id_included))].drop_duplicates()
+
+        routes_filtered.to_csv(routes_filename)


### PR DESCRIPTION
Generating routes_computed.csv for the entire national dataset takes a long time, even on HPC, and as a result we tend not to update it as often as we update the rest of the input data. This leads to a recurring error in `CostGraph` where `facility_id` values in `CostGraph` (ie, values that are in the locations dataset) are not in the routes file. See issues #37 and #25 for instance.

The commits in this PR, along with a couple commits already in `configs`, adjust the filtering and routes-generating functionality as follows:

- When executing a sub-national scale run, it's now feasible to generate a new routes_computed file just for that run. This is because the locations_computed.csv file is filtered first, and then routes are generated from that filtered file. We then avoid generating the national set of routes only to filter it down.
    - To use this workflow, set `enable_data_filtering` to `True` and `run_routes` to `True`.
- We still have the option to filter an existing routes_computed file instead of generating a new one. **When this is done, make sure the routes_computed file being used matches the rest of the input data.**
    - To use this workflow, set `enable_data_filtering` to `True` and `run_routes` to `False`.
- For both of the workflows above, `use_computed_routes` should be `True`. 
- `compute_locations` and `generate_step_costs` can be `True` or `False`, depending on how recently the raw data was updated. I've found that re-generating the locations, number_of_turbines, and step_costs files runs VERY quickly even at national scale, so on my machine I pretty much always have `compute_locations` and `generate_step_costs` set to `True`.