### PR TITLE
Refactors component.py with increment and decrement methods

### DIFF
--- a/celavi/component.py
+++ b/celavi/component.py
@@ -201,78 +201,40 @@ class Component:
                 factype = location.split('_')[0]
                 if factype in self.split_dict.keys():
                     # increment the facility inventory and transportation tracker
-                    fac_count_inventory = self.context.count_facility_inventories[location]
-                    fac_transport = self.context.transportation_trackers[location]
-                    fac_mass_inventory = self.context.mass_facility_inventories[location]
-                    fac_count_inventory.increment_quantity(
-                        self.kind,
-                        1,
-                        env.now
-                    )
+                    self.move_component_to(env, loc=location, dist=distance)
 
-                    for _, mass in self.mass_tonnes.items():
-                        fac_transport.increment_inbound_tonne_km(mass * distance, env.now)
-
-                    for material, mass in self.mass_tonnes.items():
-                        fac_mass_inventory.increment_quantity(material, mass, env.now)
-
-                    # locate the nearest landfill and increment for material loss
-                    _split_facility_1 = self.context.cost_graph.find_downstream(
-                        facility_id = int(location.split('_')[1]),
-                        connect_to = self.split_dict[factype]['facility_1']
-                    )
-                    _split_facility_2 = self.context.cost_graph.find_downstream(
-                        node_name = location,
-                        connect_to = self.split_dict[factype]['facility_2']
-                    )
-                    
-                    fac1_count_inventory = self.context.count_facility_inventories[_split_facility_1]
-                    fac1_transport = self.context.transportation_trackers[_split_facility_1]
-                    fac1_mass_inventory = self.context.mass_facility_inventories[_split_facility_1]
-                    fac1_count_inventory.increment_quantity(
-
-                        self.kind,
-                        self.split_dict[factype]['fraction'],
-                        env.now
-                    )
-
-                    for material, mass in self.mass_tonnes.items():
-                        fac1_transport.increment_inbound_tonne_km(
-                            self.split_dict[factype]['fraction'] * mass * distance,
-                            env.now
-                        )
-                        fac1_mass_inventory.increment_quantity(
-                            material,
-                            self.split_dict[factype]['fraction'] * mass,
-                            env.now
-                        )
-
-                    fac2_count_inventory = self.context.count_facility_inventories[_split_facility_2]
-                    fac2_mass_inventory = self.context.mass_facility_inventories[_split_facility_2]
-                    fac2_transport = self.context.transportation_trackers[_split_facility_2]
-                    fac2_count_inventory.increment_quantity(
-                        self.kind,
-                        1 - self.split_dict[factype]['fraction'],
-                        env.now
-                    )
-
-                    for material, mass in self.mass_tonnes.items():
-                        fac2_mass_inventory.increment_quantity(
-                            material,
-                            (1 - self.split_dict[factype]['fraction']) * mass,
-                            env.now
-                        )
-
-                        fac2_transport.increment_inbound_tonne_km(
-                            (1 - self.split_dict[factype]['fraction']) * mass * distance,
-                            env.now
-                        )
+                    self.current_location = location
 
                     yield env.timeout(lifespan)
 
-                    fac_count_inventory.increment_quantity(self.kind, -1, env.now)
-                    for material, mass in self.mass_tonnes.items():
-                        fac_mass_inventory.increment_quantity(material, -mass, env.now)
+                    self.move_component_from(env, loc=location)
+
+                    # locate the two downstream facilities that are closest
+                    _split_facility_1 = self.context.cost_graph.find_downstream(
+                        facility_id = int(location.split('_')[1]),
+                        connect_to = self.split_dict[factype]['facility_1'],
+                        get_dist=True
+                    )
+
+                    _split_facility_2 = self.context.cost_graph.find_downstream(
+                        node_name = location,
+                        connect_to = self.split_dict[factype]['facility_2'],
+                        get_dist=True
+                    )
+
+                    # Move component fractions to the split facilities
+                    self.move_component_to(
+                        env,
+                        loc=_split_facility_1[0],
+                        amt=self.split_dict[factype]['fraction'],
+                        dist=_split_facility_1[1]
+                    )
+                    self.move_component_to(
+                        env,
+                        loc=_split_facility_2[0],
+                        amt=1 - self.split_dict[factype]['fraction'],
+                        dist=_split_facility_2[1]
+                    )
 
                 elif factype in self.split_dict['pass']:
                     # the inventory and transportation was incremented when the
@@ -280,27 +242,59 @@ class Component:
                     pass
 
                 else:
-                    count_inventory = self.context.count_facility_inventories[location]
-                    mass_inventory = self.context.mass_facility_inventories[location]
-                    transport = self.context.transportation_trackers[location]
-                    count_inventory.increment_quantity(self.kind, 1, env.now)
-
-                    for material, mass in self.mass_tonnes.items():
-                        mass_inventory.increment_quantity(material, mass, env.now)
-
-                    # Again, assuming the transportation impacts are the same per unit
-                    # mass for all materials.
-                    for _, mass in self.mass_tonnes.items():
-                        transport.increment_inbound_tonne_km(mass * distance, env.now)
+                    self.move_component_to(env, loc=location, dist=distance)
 
                     self.current_location = location
 
                     yield env.timeout(lifespan)
 
-                    count_inventory.increment_quantity(self.kind, -1, env.now)
-
-                    for material, mass in self.mass_tonnes.items():
-                        mass_inventory.increment_quantity(material, -mass, env.now)
+                    self.move_component_from(env, loc=location)
 
             else:
                 break
+
+    def move_component_to(self, env, loc, dist : float, amt = 1.0):
+        """
+        Increment mass, count, and transportation inventories.
+
+        Parameters
+        ----------
+        env
+
+        amt : float
+            Number of components being moved. Defaults to 1.
+
+        loc
+            Destination facility ID
+
+        dist : float
+            Transportation distance in km to destination facility
+        """
+        self.context.count_facility_inventories[loc].increment_quantity(self.kind, amt, env.now)
+
+        for _mat, _mass in self.mass_tonnes.items():
+            self.context.mass_facility_inventories[loc].increment_quantity(_mat, amt * _mass, env.now)
+            self.context.transportation_trackers[loc].increment_inbound_tonne_km(amt * _mass * dist, env.now)
+
+    def move_component_from(self, env, loc, amt = 1.0):
+        """
+        Decrement mass and count inventories at the current facility.
+
+        Only INBOUND transportation is tracked by facility, thus no
+        transportation tracking is done by this method.
+
+        Parameters
+        ----------
+        env
+
+        loc
+            Current facility ID
+
+        amt : float
+            Number of components being moved. Defaults to 1.
+        """
+
+        self.context.count_facility_inventories[loc].increment_quantity(self.kind, -amt, env.now)
+
+        for _mat, _mass in self.mass_tonnes.items():
+            self.context.mass_facility_inventories[loc].increment_quantity(_mat, -amt * _mass, env.now)

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -772,16 +772,17 @@ class CostGraph:
                         node_name : str = None,
                         facility_id : int = None,
                         connect_to : str = 'landfill',
-                        crit : str = 'dist'):
+                        crit : str = 'dist',
+                        get_dist : bool = False):
         """
 
         Parameters
         ----------
         node_name
         facility_id
-        node_id
         connect_to
         crit
+        get_dist
 
         Returns
         -------
@@ -789,6 +790,7 @@ class CostGraph:
              of type "connect_to" downstream of the node indicated by node_id.
 
         """
+
         # Check that the node_id exists in the supply chain.
         # If it doesn't, print a message and return None
         # if a facility_id was provided, use that to locate the node
@@ -803,10 +805,46 @@ class CostGraph:
                 # node name
                 _node = [x for x, y in self.supply_chain.nodes(data=True)
                          if y['facility_id'] == facility_id][0]
+
                 # Get a list of all nodes with an outgoing edge that connects
                 # to this facility_id, with the specified facility type
                 _downst_nodes = [n for n in self.supply_chain.successors(_node)
                                  if n.find(connect_to) != -1]
+                _upstream_dists = [self.supply_chain.edges[_node, _lnd_n][crit]
+                                   for _lnd_n in _downst_nodes]
+
+                # Search the list for the "closest" node
+                if len(_downst_nodes) == 0:
+                    # If there are no upstream nodes of the correct type, print a
+                    # message and return None
+                    print(
+                        f'Node {node_name} does not have any downstream neighbors of type {connect_to}',
+                        flush=True)
+                    return None
+
+                elif len(_downst_nodes) > 1:
+                    # If there are multiple options, identify the nearest neighbor
+                    # according to the crit(eria) parameter
+
+                    _nearest_downst_node = _downst_nodes[_upstream_dists.index(
+                        min(_upstream_dists)
+                    )]
+                    _nearest_facility_id = _nearest_downst_node.split('_')[1]
+
+                    if not get_dist:
+                        return _nearest_downst_node
+                    else:
+                        return _nearest_downst_node, min(_upstream_dists)
+
+                else:
+                    # If there is only one option, pull that node's facility_id directly
+                    _nearest_downst_node = _downst_nodes[0]
+                    _upstream_dist = _upstream_dists[0]
+                    if not get_dist:
+                        return _nearest_downst_node
+                    else:
+                        return _nearest_downst_node, _upstream_dist
+
         elif node_name is not None:
             if not node_name in self.supply_chain.nodes:
                 print(f'Node {node_name} does not exist in CostGraph',
@@ -818,35 +856,37 @@ class CostGraph:
                 _downst_nodes = [n for n in
                                  self.supply_chain.successors(node_name)
                                  if n.find(connect_to) != -1]
+                _upstream_dists = [self.supply_chain.edges[node_name, _lnd_n][crit]
+                                   for _lnd_n in _downst_nodes]
+
+                if len(_downst_nodes) > 1:
+                    _nearest_downst_node = _downst_nodes[_upstream_dists.index(
+                        min(_upstream_dists)
+                    )]
+                    _nearest_facility_id = _nearest_downst_node.split('_')[1]
+
+                    if not get_dist:
+                        return _nearest_downst_node
+                    else:
+                        return _nearest_downst_node, min(_upstream_dists)
+                elif len(_downst_nodes) == 1:
+                    if not get_dist:
+                        return _downst_nodes[0]
+                    else:
+                        return _downst_nodes[0], _upstream_dists[0]
+                else:
+                    print(
+                        f'Node {node_name} does not have any downstream neighbors of type {connect_to}',
+                        flush=True)
+                    return None
         else:
             print(f'No node identifier provided to find_downstream',
                   flush=True)
             return None
 
-        # Search the list for the "closest" node
-        if len(_downst_nodes) == 0:
-            # If there are no upstream nodes of the correct type, print a
-            # message and return None
-            print(f'Node {node_name} does not have any downstream neighbors of type {connect_to}',
-                  flush=True)
-            return None
 
-        elif len(_downst_nodes) > 1:
-            # If there are multiple options, identify the nearest neighbor
-            # according to the crit(eria) parameter
 
-            _upstream_dists = [self.supply_chain.edges[_node, _lnd_n][crit]
-                               for _lnd_n in _downst_nodes]
-            _nearest_downst_node = _downst_nodes[_upstream_dists.index(
-                min(_upstream_dists)
-            )]
-            _nearest_facility_id = _nearest_downst_node.split('_')[1]
 
-        else:
-            # If there is only one option, pull that node's facility_id directly
-            _nearest_downst_node = _downst_nodes[0]
-
-        return _nearest_downst_node
 
 
     def update_costs(self, path_dict):


### PR DESCRIPTION
See issue #121 

There are two new `Component` methods:
* `move_component_to` performs all component count, material, and mass incrementing for the location provided, and also calculates and increments the transportation counter
* `move_component_from` similarly performs all component count, material and mass decrementing for the location provided. Since we're tracking inbound transportation only (to avoid double-counting), there is no transportation tracker in this method.

This update makes the `eol_process` considerably shorter and more human-readable.