### PR TITLE
add array-based uncertainty capability to develop

### DIFF
--- a/celavi/component.py
+++ b/celavi/component.py
@@ -1,6 +1,8 @@
 from typing import Deque, Tuple, Dict
 from collections import deque
 
+from celavi.scenario import apply_array_uncertainty
+
 
 class Component:
     """

--- a/celavi/component.py
+++ b/celavi/component.py
@@ -243,14 +243,20 @@ class Component:
                     self.move_component_to(
                         env,
                         loc=_split_facility_1[0],
-                        amt=self.split_dict[factype]["fraction"], # @TODO uncertainty
+                        amt=apply_array_uncertainty(
+                            self.split_dict[factype]["fraction"],
+                            self.context.run
+                            ),
                         dist=_split_facility_1[1],
                         route_id=_split_facility_1[2],
                     )
                     self.move_component_to(
                         env,
                         loc=_split_facility_2[0],
-                        amt=1 - self.split_dict[factype]["fraction"], # @TODO uncertainty
+                        amt=1 - apply_array_uncertainty(
+                            self.split_dict[factype]["fraction"],
+                            self.context.run
+                            ),
                         dist=_split_facility_2[1],
                         route_id=_split_facility_2[2],
                     )

--- a/celavi/component.py
+++ b/celavi/component.py
@@ -245,7 +245,7 @@ class Component:
                         loc=_split_facility_1[0],
                         amt=apply_array_uncertainty(
                             self.split_dict[factype]["fraction"],
-                            self.context.run
+                            self.context.model_run
                             ),
                         dist=_split_facility_1[1],
                         route_id=_split_facility_1[2],
@@ -255,7 +255,7 @@ class Component:
                         loc=_split_facility_2[0],
                         amt=1 - apply_array_uncertainty(
                             self.split_dict[factype]["fraction"],
-                            self.context.run
+                            self.context.model_run
                             ),
                         dist=_split_facility_2[1],
                         route_id=_split_facility_2[2],

--- a/celavi/component.py
+++ b/celavi/component.py
@@ -241,14 +241,14 @@ class Component:
                     self.move_component_to(
                         env,
                         loc=_split_facility_1[0],
-                        amt=self.split_dict[factype]["fraction"],
+                        amt=self.split_dict[factype]["fraction"], # @TODO uncertainty
                         dist=_split_facility_1[1],
                         route_id=_split_facility_1[2],
                     )
                     self.move_component_to(
                         env,
                         loc=_split_facility_2[0],
-                        amt=1 - self.split_dict[factype]["fraction"],
+                        amt=1 - self.split_dict[factype]["fraction"], # @TODO uncertainty
                         dist=_split_facility_2[1],
                         route_id=_split_facility_2[2],
                     )

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -89,7 +89,7 @@ class CostGraph:
         random_state : np.random.default_rng
             Instantiated random number generator for uncertainty analysis.
         """
-        self.cost_methods = CostMethods(seed=random_state)
+        self.cost_methods = CostMethods(seed=random_state, run=run)
 
         self.start_time = time()
         self.step_costs = pd.read_csv(step_costs_file)

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -2,6 +2,7 @@ import numpy as np
 import scipy.stats as st
 import warnings
 
+from celavi.scenario import apply_array_uncertainty
 
 class CostMethods:
     """

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -405,7 +405,6 @@ class CostMethods:
         else:
             # No uncertainty
             _loss = path_dict['path_split']['fine grinding']['fraction']
-            _learn_rate = _learn_dict['learn rate']
             _initial_cost = path_dict['cost uncertainty']['fine grinding']['initial cost']
             _revenue = path_dict['cost uncertainty']['fine grinding']['revenue']['b']
 

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -60,13 +60,25 @@ class CostMethods:
             Landfill tipping fee in USD/metric ton
         """
         _year = path_dict['year']
-        _fee = 8.0E-30 * np.exp(0.0352 * _year)
+        _fee = 1.5921*_year - 3155.3 # deterministic national average
 
-        if path_dict['cost_uncertainty']['landfilling']:
+        if path_dict['cost_uncertainty']['landfilling'] == 'random':
             _c = path_dict['cost_uncertainty']['landfilling']['c']
             _loc = path_dict['cost_uncertainty']['landfilling']['loc']
             _scale = path_dict['cost_uncertainty']['landfilling']['scale']
             return st.triang.rvs(c=_c,loc=_loc*_fee,scale=_scale*_fee, random_state=self.seed)
+        elif path_dict['cost_uncertainty']['landfilling'] == 'array':
+            # in post-2020 (last historical data point)
+            if _year >= 2021:
+                # use an array of parameter values from config
+                # model run is the index
+                # parse as float value (defaults to string)
+                _param = float(path_dict['cost_uncertainty']['landfilling']['param'][self.run])
+                # fee model = point-slope form of a line
+                return _param(_year - 2020) + 59.23
+            else:
+                # if the year is 2020 or earlier, just return the historical model
+                return _fee
         else:
             return _fee
 

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -575,7 +575,7 @@ class CostMethods:
         if _vkmt is None:
             return 0.0
         else:
-            if path_dict['cost uncertainty']['shred transpo'] == 'array':
+            if path_dict['cost uncertainty']['shred transpo']['uncertainty'] == 'array':
                 if _year >= 2021.0:
                     _m = apply_array_uncertainty(
                         path_dict['cost uncertainty']['shred transpo']['m'],
@@ -584,8 +584,8 @@ class CostMethods:
                     _b = apply_array_uncertainty(
                         path_dict['cost uncertainty']['shred transpo']['b'],
                         self.run
-                        )                        
-                    return (_m * _year + _b) * _vkmt
+                        )
+                    return (_m * (_year - 2020.0) + _b) * _vkmt
                 else:
                     return _cost * _vkmt
 

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -15,13 +15,19 @@ class CostMethods:
 
     def __init__(self, seed, run):
         """
-        Provide a random number generator to all uncertain CostMethods.
+        Provide a random number generator and model run to all uncertain
+        CostMethods.
 
+        Parameters
+        ----------
+        seed : np.random.default_rng
+            Instantiated random number generator for uncertainty analysis.
+
+        run : int
+            Model run number.
         """
         self.seed = seed
         self.run = run
-        # @TODO Check that all uncertainty types are random, array, or blank
-        # @TODO Run length check on all cost models with array uncertainty type
 
 
     @staticmethod
@@ -31,7 +37,7 @@ class CostMethods:
 
         Parameters
         ----------
-        path_dict
+        path_dict : dict
             Dictionary of variable structure containing cost parameters for
             calculating and updating processing costs for circularity pathway
             processes.

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -140,7 +140,7 @@ class CostMethods:
                     path_dict['cost uncertainty']['rotor teardown']['b'],
                     self.run
                     )
-                return (_m * _year  + _b) / _mass
+                return (_m * (_year - 2020.0)  + _b) / _mass
             else:
                 return _cost / _mass
         else:

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -2,7 +2,6 @@ import numpy as np
 import scipy.stats as st
 import warnings
 
-from celavi.scenario import apply_array_uncertainty
 
 class CostMethods:
     """
@@ -30,6 +29,13 @@ class CostMethods:
         self.seed = seed
         self.run = run
     
+    @staticmethod
+    def apply_array_uncertainty(quantity, run):
+        """Use model run number to access one element in a parameter list."""
+        if not isinstance(quantity, list):
+            return float(quantity)
+        else:
+            return float(quantity[run])
 
     @staticmethod
     def zero_method(path_dict):
@@ -82,7 +88,7 @@ class CostMethods:
                 # use an array of parameter values from config
                 # model run is the index
                 # parse as float value (defaults to string)
-                _m = apply_array_uncertainty(
+                _m = self.apply_array_uncertainty(
                     path_dict['cost uncertainty']['landfilling']['m'],
                     self.run
                     )
@@ -129,7 +135,7 @@ class CostMethods:
             return st.triang.rvs(c=_c, loc=_loc*_cost, scale=_scale*_cost, random_state=self.seed)
         elif path_dict['cost uncertainty']['rotor teardown']['uncertainty'] == 'array':
             if _year >= 2021:
-                _m = apply_array_uncertainty(
+                _m = self.apply_array_uncertainty(
                     path_dict['cost uncertainty']['rotor teardown']['m'],
                     self.run
                     )
@@ -167,7 +173,7 @@ class CostMethods:
             return st.triang.rvs(c=_c, loc=_loc*_cost, scale=_scale*_cost, random_state=self.seed)
         elif path_dict['cost uncertainty']['segmenting']['uncertainty'] == 'array':
             if _year >= 2021:
-                return apply_array_uncertainty(
+                return self.apply_array_uncertainty(
                     path_dict['cost uncertainty']['segmenting']['b'],
                     self.run
                     )
@@ -213,11 +219,11 @@ class CostMethods:
         if path_dict['cost uncertainty']['coarse grinding onsite']['uncertainty'] == 'array':
             # Array uncertainty is applied to the initial cost or to the learning rate
             # (array uncertainty for the actual cost is implemented through the learning rate)
-            _learn_rate = apply_array_uncertainty(
+            _learn_rate = self.apply_array_uncertainty(
                 _learn_dict['learn rate'],
                 self.run
                 )
-            _initial_cost = apply_array_uncertainty(
+            _initial_cost = self.apply_array_uncertainty(
                 path_dict['cost uncertainty']['coarse grinding onsite']['initial cost'],
                 self.run
                 )
@@ -289,11 +295,11 @@ class CostMethods:
         if path_dict['cost uncertainty']['coarse grinding']['uncertainty'] == 'array':
             # Array uncertainty is applied to the initial cost or to the learning rate
             # (array uncertainty for the actual cost is implemented through the learning rate)
-            _learn_rate = apply_array_uncertainty(
+            _learn_rate = self.apply_array_uncertainty(
                 _learn_dict['learn rate'],
                 self.run
                 )
-            _initial_cost = apply_array_uncertainty(
+            _initial_cost = self.apply_array_uncertainty(
                 path_dict['cost uncertainty']['coarse grinding']['initial cost'],
                 self.run
                 )
@@ -364,19 +370,19 @@ class CostMethods:
 
         # Implement uncertainty on parameters: array or random
         if path_dict['cost uncertainty']['fine grinding']['uncertainty'] == 'array':
-            _loss = apply_array_uncertainty(
+            _loss = self.apply_array_uncertainty(
                 path_dict['path_split']['fine grinding']['fraction'],
                 self.run
             )
-            _learn_rate = apply_array_uncertainty(
+            _learn_rate = self.apply_array_uncertainty(
                 _learn_dict['learn rate'],
                 self.run
             )
-            _initial_cost = apply_array_uncertainty(
+            _initial_cost = self.apply_array_uncertainty(
                path_dict['cost uncertainty']['fine grinding']['initial cost'],
                self.run
             )
-            _revenue = apply_array_uncertainty(
+            _revenue = self.apply_array_uncertainty(
                 path_dict['cost uncertainty']['fine grinding']['revenue']['b'],
                 self.run
             )
@@ -469,7 +475,7 @@ class CostMethods:
             _scale = path_dict['cost uncertainty']['coprocessing']['scale']
             return -1.0 * st.triang.rvs(c=_c, loc = _loc*_revenue, scale=_scale*_revenue, random_state=self.seed)
         elif path_dict['cost uncertainty']['coprocessing']['uncertainty'] == 'array':
-            return -1.0 * apply_array_uncertainty(
+            return -1.0 * self.apply_array_uncertainty(
                 path_dict['cost uncertainty']['coprocessing']['b'],
                 self.run
                 )
@@ -502,34 +508,34 @@ class CostMethods:
             return 0.0
         else:
             if _year < 2001.0 or 2002.0 <= _year < 2003.0:
-                _cost = apply_array_uncertainty(
+                _cost = self.apply_array_uncertainty(
                     path_dict['cost uncertainty']['segment transpo']['cost 1'],
                     self.run
                 )
             elif 2001.0 <= _year < 2002.0 or 2003.0 <= _year < 2019.0:
-                _cost = apply_array_uncertainty(
+                _cost = self.apply_array_uncertainty(
                     path_dict['cost uncertainty']['segment transpo']['cost 2'],
                     self.run
                 )
             elif 2019.0 <= _year < 2031.0:
-                _cost = apply_array_uncertainty(
+                _cost = self.apply_array_uncertainty(
                     path_dict['cost uncertainty']['segment transpo']['cost 3'],
                     self.run
                 )
             elif 2031.0 <= _year < 2044.0:
-                _cost = apply_array_uncertainty(
+                _cost = self.apply_array_uncertainty(
                     path_dict['cost uncertainty']['segment transpo']['cost 4'],
                     self.run
                 )
             elif 2044.0 <= _year <= 2050.0:
-                _cost = apply_array_uncertainty(
+                _cost = self.apply_array_uncertainty(
                     path_dict['cost uncertainty']['segment transpo']['cost 5'],
                     self.run
                 )
             else:
                 warnings.warn(
                     'Year out of range for segment transport; using cost 4')
-                _cost = apply_array_uncertainty(
+                _cost = self.apply_array_uncertainty(
                     path_dict['cost uncertainty']['segment transpo']['cost 4'],
                     self.run
                 )
@@ -571,7 +577,7 @@ class CostMethods:
         else:
             if path_dict['cost uncertainty']['shred transpo'] == 'array':
                 if _year >= 2021.0:
-                    _m = apply_array_uncertainty(
+                    _m = self.apply_array_uncertainty(
                         path_dict['cost uncertainty']['shred transpo']['m'],
                         self.run
                         )
@@ -612,7 +618,7 @@ class CostMethods:
         """
         _cost = 11440.0
         if path_dict['cost uncertainty']['manufacturing']['uncertainty'] == 'array' and path_dict['year'] > 2021.0:
-            _cost = apply_array_uncertainty(
+            _cost = self.apply_array_uncertainty(
                 path_dict['cost uncertainty']['manufacturing']['b'],
                 self.run
                 )
@@ -623,7 +629,6 @@ class CostMethods:
             return st.triang.rvs(c=_c, loc=_loc*_cost, scale=_scale*_cost, random_state=self.seed)
         else:
             return _cost
-
 
 
     def blade_transpo(self, path_dict):

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -2,6 +2,7 @@ import numpy as np
 import scipy.stats as st
 import warnings
 
+from celavi.scenario import apply_array_uncertainty
 
 class CostMethods:
     """
@@ -28,14 +29,6 @@ class CostMethods:
         """
         self.seed = seed
         self.run = run
-    
-    @staticmethod
-    def apply_array_uncertainty(quantity, run):
-        """Use model run number to access one element in a parameter list."""
-        if not isinstance(quantity, list):
-            return float(quantity)
-        else:
-            return float(quantity[run])
 
     @staticmethod
     def zero_method(path_dict):
@@ -88,7 +81,7 @@ class CostMethods:
                 # use an array of parameter values from config
                 # model run is the index
                 # parse as float value (defaults to string)
-                _m = self.apply_array_uncertainty(
+                _m = apply_array_uncertainty(
                     path_dict['cost uncertainty']['landfilling']['m'],
                     self.run
                     )
@@ -135,7 +128,7 @@ class CostMethods:
             return st.triang.rvs(c=_c, loc=_loc*_cost, scale=_scale*_cost, random_state=self.seed)
         elif path_dict['cost uncertainty']['rotor teardown']['uncertainty'] == 'array':
             if _year >= 2021:
-                _m = self.apply_array_uncertainty(
+                _m = apply_array_uncertainty(
                     path_dict['cost uncertainty']['rotor teardown']['m'],
                     self.run
                     )
@@ -173,7 +166,7 @@ class CostMethods:
             return st.triang.rvs(c=_c, loc=_loc*_cost, scale=_scale*_cost, random_state=self.seed)
         elif path_dict['cost uncertainty']['segmenting']['uncertainty'] == 'array':
             if _year >= 2021:
-                return self.apply_array_uncertainty(
+                return apply_array_uncertainty(
                     path_dict['cost uncertainty']['segmenting']['b'],
                     self.run
                     )
@@ -219,11 +212,11 @@ class CostMethods:
         if path_dict['cost uncertainty']['coarse grinding onsite']['uncertainty'] == 'array':
             # Array uncertainty is applied to the initial cost or to the learning rate
             # (array uncertainty for the actual cost is implemented through the learning rate)
-            _learn_rate = self.apply_array_uncertainty(
+            _learn_rate = apply_array_uncertainty(
                 _learn_dict['learn rate'],
                 self.run
                 )
-            _initial_cost = self.apply_array_uncertainty(
+            _initial_cost = apply_array_uncertainty(
                 path_dict['cost uncertainty']['coarse grinding onsite']['initial cost'],
                 self.run
                 )
@@ -295,11 +288,11 @@ class CostMethods:
         if path_dict['cost uncertainty']['coarse grinding']['uncertainty'] == 'array':
             # Array uncertainty is applied to the initial cost or to the learning rate
             # (array uncertainty for the actual cost is implemented through the learning rate)
-            _learn_rate = self.apply_array_uncertainty(
+            _learn_rate = apply_array_uncertainty(
                 _learn_dict['learn rate'],
                 self.run
                 )
-            _initial_cost = self.apply_array_uncertainty(
+            _initial_cost = apply_array_uncertainty(
                 path_dict['cost uncertainty']['coarse grinding']['initial cost'],
                 self.run
                 )
@@ -370,19 +363,19 @@ class CostMethods:
 
         # Implement uncertainty on parameters: array or random
         if path_dict['cost uncertainty']['fine grinding']['uncertainty'] == 'array':
-            _loss = self.apply_array_uncertainty(
+            _loss = apply_array_uncertainty(
                 path_dict['path_split']['fine grinding']['fraction'],
                 self.run
             )
-            _learn_rate = self.apply_array_uncertainty(
+            _learn_rate = apply_array_uncertainty(
                 _learn_dict['learn rate'],
                 self.run
             )
-            _initial_cost = self.apply_array_uncertainty(
+            _initial_cost = apply_array_uncertainty(
                path_dict['cost uncertainty']['fine grinding']['initial cost'],
                self.run
             )
-            _revenue = self.apply_array_uncertainty(
+            _revenue = apply_array_uncertainty(
                 path_dict['cost uncertainty']['fine grinding']['revenue']['b'],
                 self.run
             )
@@ -475,7 +468,7 @@ class CostMethods:
             _scale = path_dict['cost uncertainty']['coprocessing']['scale']
             return -1.0 * st.triang.rvs(c=_c, loc = _loc*_revenue, scale=_scale*_revenue, random_state=self.seed)
         elif path_dict['cost uncertainty']['coprocessing']['uncertainty'] == 'array':
-            return -1.0 * self.apply_array_uncertainty(
+            return -1.0 * apply_array_uncertainty(
                 path_dict['cost uncertainty']['coprocessing']['b'],
                 self.run
                 )
@@ -508,34 +501,34 @@ class CostMethods:
             return 0.0
         else:
             if _year < 2001.0 or 2002.0 <= _year < 2003.0:
-                _cost = self.apply_array_uncertainty(
+                _cost = apply_array_uncertainty(
                     path_dict['cost uncertainty']['segment transpo']['cost 1'],
                     self.run
                 )
             elif 2001.0 <= _year < 2002.0 or 2003.0 <= _year < 2019.0:
-                _cost = self.apply_array_uncertainty(
+                _cost = apply_array_uncertainty(
                     path_dict['cost uncertainty']['segment transpo']['cost 2'],
                     self.run
                 )
             elif 2019.0 <= _year < 2031.0:
-                _cost = self.apply_array_uncertainty(
+                _cost = apply_array_uncertainty(
                     path_dict['cost uncertainty']['segment transpo']['cost 3'],
                     self.run
                 )
             elif 2031.0 <= _year < 2044.0:
-                _cost = self.apply_array_uncertainty(
+                _cost = apply_array_uncertainty(
                     path_dict['cost uncertainty']['segment transpo']['cost 4'],
                     self.run
                 )
             elif 2044.0 <= _year <= 2050.0:
-                _cost = self.apply_array_uncertainty(
+                _cost = apply_array_uncertainty(
                     path_dict['cost uncertainty']['segment transpo']['cost 5'],
                     self.run
                 )
             else:
                 warnings.warn(
                     'Year out of range for segment transport; using cost 4')
-                _cost = self.apply_array_uncertainty(
+                _cost = apply_array_uncertainty(
                     path_dict['cost uncertainty']['segment transpo']['cost 4'],
                     self.run
                 )
@@ -577,7 +570,7 @@ class CostMethods:
         else:
             if path_dict['cost uncertainty']['shred transpo'] == 'array':
                 if _year >= 2021.0:
-                    _m = self.apply_array_uncertainty(
+                    _m = apply_array_uncertainty(
                         path_dict['cost uncertainty']['shred transpo']['m'],
                         self.run
                         )
@@ -618,7 +611,7 @@ class CostMethods:
         """
         _cost = 11440.0
         if path_dict['cost uncertainty']['manufacturing']['uncertainty'] == 'array' and path_dict['year'] > 2021.0:
-            _cost = self.apply_array_uncertainty(
+            _cost = apply_array_uncertainty(
                 path_dict['cost uncertainty']['manufacturing']['b'],
                 self.run
                 )

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -81,8 +81,7 @@ class CostMethods:
                 # use an array of parameter values from config
                 # model run is the index
                 # parse as float value (defaults to string)
-                # @NOTE Way to avoid using eval?
-                _m = eval(path_dict['cost_uncertainty']['landfilling']['m'][self.run])
+                _m = float(path_dict['cost_uncertainty']['landfilling']['m'][self.run])
                 # fee model = point-slope form of a line
                 return _m * (_year - 2020) + 59.23
             else:

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -90,7 +90,7 @@ class CostMethods:
                     self.run
                     )
                 # fee model = point-slope form of a line
-                return _m * _year + _b
+                return _m * (_year - 2020.0) + _b
             else:
                 # if the year is 2020 or earlier, just return the historical model
                 return _fee

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -2,6 +2,7 @@ import numpy as np
 import scipy.stats as st
 import warnings
 
+from typing import Dict
 from celavi.scenario import apply_array_uncertainty
 
 class CostMethods:

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -373,13 +373,12 @@ class CostMethods:
             _learn_dict['learn rate'],
             self.run
             )
-
+        _loss = apply_array_uncertainty(
+            path_dict['path_split']['fine grinding']['fraction'],
+            self.run
+        )        
         # Implement uncertainty on parameters: array or random
         if path_dict['cost uncertainty']['fine grinding']['uncertainty'] == 'array':
-            _loss = apply_array_uncertainty(
-                path_dict['path_split']['fine grinding']['fraction'],
-                self.run
-            )
             _initial_cost = apply_array_uncertainty(
                path_dict['cost uncertainty']['fine grinding']['initial cost'],
                self.run
@@ -390,7 +389,6 @@ class CostMethods:
             )
         elif path_dict['cost uncertainty']['fine grinding']['uncertainty'] == 'random':
             # Random uncertainty applies only to the revenue
-            _loss = path_dict['path_split']['fine grinding']['fraction']
             _initial_cost = path_dict['cost uncertainty']['fine grinding']['initial cost']
             # Parameters for fine grinding revenue
             _c_fgr = path_dict['cost uncertainty']['fine grinding']['revenue']['c']
@@ -404,7 +402,6 @@ class CostMethods:
             )            
         else:
             # No uncertainty
-            _loss = path_dict['path_split']['fine grinding']['fraction']
             _initial_cost = path_dict['cost uncertainty']['fine grinding']['initial cost']
             _revenue = path_dict['cost uncertainty']['fine grinding']['revenue']['b']
 

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -101,14 +101,14 @@ class CostMethods:
 
         Parameters
         ----------
-        path_dict
+        path_dict : dict
             Dictionary of variable structure containing cost parameters for
             calculating and updating processing costs for circularity pathway
             processes
 
         Returns
         -------
-        _cost
+        _cost : float
             Cost in USD per metric ton of removing a blade from an
             in-use turbine. Equivalent to 1/3 the rotor teardown cost divided
             by the blade mass.
@@ -116,15 +116,19 @@ class CostMethods:
 
         _year = path_dict['year']
         _mass = path_dict['component mass']
-        _cost = (42.6066109 * _year ** 2 -
-                 170135.7518957 * _year +
-                 169851728.663209) / _mass
+        _cost = 1467.08 * _year - 2933875.40 # Linear national average cost model
 
-        if path_dict['cost_uncertainty']['rotor_teardown']:
+        if path_dict['cost_uncertainty']['rotor_teardown']['uncertainty'] == 'random':
             _c = path_dict['cost_uncertainty']['rotor_teardown']['c']
             _loc = path_dict['cost_uncertainty']['rotor_teardown']['loc']
             _scale = path_dict['cost_uncertainty']['rotor_teardown']['scale']
             return st.triang.rvs(c=_c, loc=_loc*_cost, scale=_scale*_cost, random_state=self.seed)
+        elif path_dict['cost_uncertainty']['rotor_teardown']['uncertainty'] == 'array':
+            if _year >= 2021:
+                _m = float(path_dict['cost_uncertainty']['rotor_teardown']['m'][self.run])
+                return _m * (_year - 2020) + 27749.82
+            else:
+                return _cost
         else:
             return _cost
 

--- a/celavi/des.py
+++ b/celavi/des.py
@@ -40,7 +40,7 @@ class Context:
         end_year: int = 2050,
         max_timesteps: int = 600,
         timesteps_per_year: int = 12,
-        run : int = 0
+        model_run : int = 0
     ):
         """
         Parameters
@@ -91,11 +91,11 @@ class Context:
             The number of timesteps in one simulation year. Default value is 12
             timesteps per year, corresponding to a monthly model resolution.
 
-        run : int
+        model_run : int
             Model run identifier
         """
 
-        self.run = run
+        self.model_run = model_run
         self.path_dict = path_dict
         self.max_timesteps = max_timesteps
         self.min_year = min_year

--- a/celavi/des.py
+++ b/celavi/des.py
@@ -40,6 +40,7 @@ class Context:
         end_year: int = 2050,
         max_timesteps: int = 600,
         timesteps_per_year: int = 12,
+        run : int = 0
     ):
         """
         Parameters
@@ -89,8 +90,12 @@ class Context:
         timesteps_per_year: int
             The number of timesteps in one simulation year. Default value is 12
             timesteps per year, corresponding to a monthly model resolution.
+
+        run : int
+            Model run identifier
         """
 
+        self.run = run
         self.path_dict = path_dict
         self.max_timesteps = max_timesteps
         self.min_year = min_year

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -359,13 +359,15 @@ class Scenario:
         # from scratch.
         if self.run > 0:
             self.netw.run = self.run
-            self.lca.run = self.run
+            self.netw.cost_methods.run = self.run
             self.netw.year = start_year
             self.netw.path_dict["year"] = start_year
             self.netw.path_dict["component mass"] = component_total_mass.loc[
                 component_total_mass.year == start_year, "mass_tonnes"
             ].values[0]
             self.netw.pathway_crit_history = list()
+
+            self.lca.run = self.run
 
         timesteps_per_year = self.case["model_run"].get("timesteps_per_year")
         des_timesteps = int(
@@ -406,6 +408,7 @@ class Scenario:
             min_year=start_year,
             max_timesteps=des_timesteps,
             timesteps_per_year=timesteps_per_year,
+            run=self.run
         )
 
         print(f"Context initialized at {self.simtime(self.start)} s", flush=True)

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -116,14 +116,6 @@ class Scenario:
         # Print run finish message
         print(f"FINISHED RUN at {self.simtime(self.start)} s", flush=True)
 
-    @staticmethod
-    def apply_array_uncertainty(quantity, run):
-        """Use model run number to access one element in a parameter list."""
-        if not isinstance(quantity, list):
-            return float(quantity)
-        else:
-            return float(quantity[run])
-
     def get_filepaths(self):
         """
         Check that input files exist and assemble paths.
@@ -247,7 +239,7 @@ class Scenario:
         if self.scen["flags"].get("initialize_costgraph", True):
             _array_len = []
             _array_methods = []
-            for _cost, _unc_type in self.scen["circular_pathways"]["cost_uncertainty"].items():
+            for _cost, _unc_type in self.scen["circular_pathways"]["cost uncertainty"].items():
                 # Check that all Cost Method uncertainty types in Scenario.yaml 
                 # are random, array, or blank (None)
                 if _unc_type["uncertainty"] not in ['random', 'array', None]:

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -117,12 +117,12 @@ class Scenario:
         print(f"FINISHED RUN at {self.simtime(self.start)} s", flush=True)
 
     @staticmethod
-    def apply_array_uncertainty(run, quantity):
+    def apply_array_uncertainty(quantity, run):
         """Use model run number to access one element in a parameter list."""
         if not isinstance(quantity, list):
-            return quantity
+            return float(quantity)
         else:
-            return quantity[run]
+            return float(quantity[run])
 
     def get_filepaths(self):
         """

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -210,7 +210,7 @@ class Scenario:
                 )
             if not self.scen["flags"].get("run_routes", True):
                 print(f"Filtering routes: {states_to_filter}", flush=True)
-                filter_routes(self.files["locations.computed"], _routefile)
+                filter_routes(self.files["locations_computed"], _routefile)
 
         if self.scen["flags"].get("run_routes", True):
             Router.get_all_routes(
@@ -278,7 +278,7 @@ class Scenario:
                 pickle.dump(self.netw, open(self.files["costgraph_pickle"], "wb"))
 
         else:
-            self.netw = pickle.load(open(self.files["costgraph_pickle"], "wb"))
+            self.netw = pickle.load(open(self.files["costgraph_pickle"], "rb"))
             print(f"CostGraph read in at {self.simtime(self.start)}", flush=True)
 
         # Electricity spatial mix level. Defaults to 'state' when not provided.

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -408,7 +408,7 @@ class Scenario:
             min_year=start_year,
             max_timesteps=des_timesteps,
             timesteps_per_year=timesteps_per_year,
-            run=self.run
+            model_run=self.run
         )
 
         print(f"Context initialized at {self.simtime(self.start)} s", flush=True)

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -14,6 +14,13 @@ import pandas as pd
 
 from scipy.stats import weibull_min
 
+def apply_array_uncertainty(quantity, run):
+    """Use model run number to access one element in a parameter list."""
+    if not isinstance(quantity, list):
+        return float(quantity)
+    else:
+        return float(quantity[run])
+
 from celavi.routing import Router
 from celavi.costgraph import CostGraph
 from celavi.compute_locations import ComputeLocations

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -237,9 +237,24 @@ class Scenario:
         )
 
         if self.scen["flags"].get("initialize_costgraph", True):
-            # @TODO Check that all Cost Method uncertainty types in Scenario.yaml 
-            # are random, array, or blank
-            # @TODO Run length check on all cost models with array uncertainty type
+            _array_len = []
+            _array_methods = []
+            for _cost, _unc_type in self.scen["circular_pathways"]["cost_uncertainty"].items():
+                # Check that all Cost Method uncertainty types in Scenario.yaml 
+                # are random, array, or blank (None)
+                if _unc_type["uncertainty"] not in ['random', 'array', None]:
+                    print(f"{_cost} uncertainty type is {_unc_type}: must be one of ['random', 'array', None]")
+                    raise NotImplementedError
+                # Assemble the parameter arrays for a length check
+                if _unc_type["uncertainty"] == 'array':
+                    _array_methods.append(_cost)
+                    _array_len.append(len(_unc_type["m"]) if _unc_type["m"] is not None else None)
+                    _array_len.append(len(_unc_type["b"]) if _unc_type["b"] is not None else None)
+
+            # Run length check on all cost models with array uncertainty type
+            if len(set([i for i in _array_len if i])) not in [0, 1]:
+                print(f"Parameters with array type uncertainty must have arrays of identical length: {_array_methods}")
+                raise NotImplementedError
 
             # Initialize the CostGraph using these parameter settings
             print(f"CostGraph starts at {self.simtime(self.start)} s", flush=True)

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -237,6 +237,10 @@ class Scenario:
         )
 
         if self.scen["flags"].get("initialize_costgraph", True):
+            # @TODO Check that all Cost Method uncertainty types in Scenario.yaml 
+            # are random, array, or blank
+            # @TODO Run length check on all cost models with array uncertainty type
+
             # Initialize the CostGraph using these parameter settings
             print(f"CostGraph starts at {self.simtime(self.start)} s", flush=True)
             self.netw = CostGraph(

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -116,6 +116,14 @@ class Scenario:
         # Print run finish message
         print(f"FINISHED RUN at {self.simtime(self.start)} s", flush=True)
 
+    @staticmethod
+    def apply_array_uncertainty(run, quantity):
+        """Use model run number to access one element in a parameter list."""
+        if not isinstance(quantity, list):
+            return quantity
+        else:
+            return quantity[run]
+
     def get_filepaths(self):
         """
         Check that input files exist and assemble paths.
@@ -329,7 +337,7 @@ class Scenario:
             use_shortcut_lca_calculations=self.scen["flags"].get(
                 "use_lcia_shortcut", True
             ),
-            substitution_rate=self.scen["technology_components"].get(
+            substitution_rate=self.scen["technology_components"].get( # @TODO uncertainty
                 "substitution_rates"
             ),
             run=self.run,
@@ -434,7 +442,7 @@ class Scenario:
         for component in (
             self.scen["technology_components"].get("component_list").keys()
         ):
-            lifespan_fns[component] = (
+            lifespan_fns[component] = ( # @TODO uncertainty
                 lambda steps=self.scen["technology_components"].get(
                     "component_fixed_lifetimes"
                 )[component], convert=timesteps_per_year: steps

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -244,25 +244,6 @@ class Scenario:
         )
 
         if self.scen["flags"].get("initialize_costgraph", True):
-            # _array_len = []
-            # _array_methods = []
-            # for _cost, _unc_type in self.scen["circular_pathways"]["cost uncertainty"].items():
-            #     # Check that all Cost Method uncertainty types in Scenario.yaml 
-            #     # are random, array, or blank (None)
-            #     if _unc_type["uncertainty"] not in ['random', 'array', None]:
-            #         print(f"{_cost} uncertainty type is {_unc_type}: must be one of ['random', 'array', None]")
-            #         raise NotImplementedError
-            #     # Assemble the parameter arrays for a length check
-            #     if _unc_type["uncertainty"] == 'array':
-            #         _array_methods.append(_cost)
-            #         _array_len.append(len(_unc_type["m"]) if _unc_type["m"] is not None else None)
-            #         _array_len.append(len(_unc_type["b"]) if _unc_type["b"] is not None else None)
-
-            # # Run length check on all cost models with array uncertainty type
-            # if len(set([i for i in _array_len if i])) not in [0, 1]:
-            #     print(f"Parameters with array type uncertainty must have arrays of identical length: {_array_methods}")
-            #     raise NotImplementedError
-
             # Initialize the CostGraph using these parameter settings
             print(f"CostGraph starts at {self.simtime(self.start)} s", flush=True)
             self.netw = CostGraph(

--- a/docs/doc_config.rst
+++ b/docs/doc_config.rst
@@ -97,6 +97,8 @@ Case Study Config Template
 Scenario Config Template
 ------------------------
 
+The `cost uncertainty` dictionary (an element of the `circular_pathways` dictionary) structure can be adjusted based on the modeling requirements of a particular case study. The structure here can apply to cost models that depend linearly on time and can take on random or array-based uncertainty.
+
 .. code-block:: yaml
 
 	flags:
@@ -132,15 +134,17 @@ Scenario Config Template
 				revenue:        # Revenue (USD/mass) from this processing step (may be zero).
 				learn rate:     # Rate at which industrial learning-by-doing reduces costs. Must be negative.
 				steps:          # List of processing steps where this cost model is applied.
-		cost_uncertainty:       # Dictionary of probability distribution parameters for cost models.
+		cost uncertainty:       # Dictionary of probability distribution parameters for cost models.
 			[process step]:     # Name of process step for the cost model. 
-				uncertainty:    # Boolean (True/False): whether to implement uncertainty for this process step.
-				c:              # c, loc, scale: Probability distribution parameter(s); can be re-named depending on distribution. See https://docs.scipy.org/doc/scipy/reference/stats.html.
+				uncertainty:    # random or array to implement uncertainty; leave blank for no uncertainty.
+				c:              # c, loc, scale: Probability distribution parameter(s) for random uncertainty type; can be re-named depending on distribution. See https://docs.scipy.org/doc/scipy/reference/stats.html.
 				loc: 
 				scale: 
+				m:              # m, b: Cost model parameter(s) for array uncertainty type; can be scalars or lists of equal length.
+				b:
 		path_split:             # Dictionary defining any process steps where the material stream splits, e.g. for material losses.
 			[process step]:     # Name of process step where split occurs.
-				fraction: 0.3   # Float; fraction of material sent to facility_1 type
+				fraction:       # Float or list of floats; fraction of material sent to facility_1 type
 				facility_1:     # Downstream facility type where fraction of material is sent.
 				facility_2:     # Downstream facility type where 1 - fraction of material is sent.
 			pass:               # Facility type(s) to ignore in DES because material was sent there during the split.

--- a/docs/doc_costgraph.rst
+++ b/docs/doc_costgraph.rst
@@ -13,3 +13,123 @@ Cost Methods are user-defined functions for calculating process costs.
 
 .. automodule:: celavi.costmethods
     :members:
+
+Wind Blade `path_dict` Structure
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Because the `circular_pathways` and in particular the `cost uncertainty` dictionaries can vary in structure, here we include the complete dictionary for the wind blade case study. This version of the dictionary is for a single model run that does not include uncertainty. Quantities that may take on array-based uncertainty are indicated with comments.
+
+.. code-block:: yaml
+
+	circular_pathways:
+		sc_begin: manufacturing
+		sc_end: 
+		- landfilling
+		- cement co-processing
+		- next use
+		learning:
+			coarse grinding:
+				component : blade
+				initial cumul: 1.0
+				cumul: 
+				learn rate: -0.05        # Define a list for array-based uncertainty.
+				steps:
+				- coarse grinding
+				- coarse grinding onsite
+			fine grinding:
+				component : blade
+				initial cumul: 1.0
+				cumul:
+				learn rate: -0.05        # Define a list for array-based uncertainty.
+				steps:
+				- fine grinding
+		cost uncertainty:
+			landfilling:
+				uncertainty:
+				c: 0.5
+				loc: 0.8
+				scale: 0.4
+				m: 1.5921                # Define a list for array-based uncertainty.
+				b: 59.23                 # Define a list for array-based uncertainty.
+			rotor teardown:
+				uncertainty:
+				c: 0.5
+				loc: 0.8
+				scale: 0.4
+				m: 1467.08               # Define a list for array-based uncertainty.
+				b: 29626.0               # Define a list for array-based uncertainty.
+			segmenting:
+				uncertainty:
+				c: 0.5
+				loc: 0.8
+				scale: 0.4
+				b: 27.56                 # Define a list for array-based uncertainty.
+			coarse grinding onsite:
+				uncertainty:
+				actual cost:
+					c: 0.5
+					loc: 0.8
+					scale: 0.4
+				initial cost: 106        # Define a list for array-based uncertainty.
+			coarse grinding:
+				uncertainty:
+				actual cost:
+					c: 0.5
+					loc: 0.8
+					scale: 0.4
+				initial cost: 106        # Define a list for array-based uncertainty.
+			fine grinding:
+				uncertainty:
+				actual cost:
+					c: 0.5
+					loc: 0.8
+					scale: 0.4
+				initial cost: 143       # Define a list for array-based uncertainty.
+				revenue:     
+					c: 0.5
+					loc: 0.8
+					scale: 0.4
+					b: 273              # Define a list for array-based uncertainty.
+			coprocessing:
+				uncertainty:
+				c: 0.5
+				loc: 0.8
+				scale: 0.4
+				b: 10.37                # Define a list for array-based uncertainty.
+			segment transpo:
+				uncertainty:
+				c: 0.5
+				loc: 0.8
+				scale: 0.4
+				cost 1: 4.35 # Before 2001; 2002-2003; Define a list for array-based uncertainty.
+				cost 2: 8.70 # 2001-2002; 2003-2019; Define a list for array-based uncertainty.
+				cost 3: 13.05 # 2019-2031; Define a list for array-based uncertainty.
+				cost 4: 17.40 # 2031-2044; Define a list for array-based uncertainty.
+				cost 5: 21.75 # 2044-2050; Define a list for array-based uncertainty.
+			shred transpo:
+				uncertainty:
+				c: 0.5
+				loc: 0.8
+				scale: 0.4
+				m: 0.0011221            # Define a list for array-based uncertainty.
+				b: 0.0739               # Define a list for array-based uncertainty.
+			manufacturing:
+				uncertainty:
+				c: 0.5
+				loc: 0.8
+				scale: 0.4
+				b: 11440.0               # Define a list for array-based uncertainty.
+		path_split: 
+			fine grinding:
+				fraction: 0.3            # Define a list for array-based uncertainty.
+				facility_1: landfilling
+				facility_2: next use  
+			pass:
+				next use
+		permanent_lifespan_facility: 
+		- landfilling
+		- cement co-processing
+		- next use
+		vkmt : 
+		component mass : 
+		year : 


### PR DESCRIPTION
See issue #156 

@akey7 I have a specific question on this PR. I have a static method currently in CostMethods called `apply_array_uncertainty`. It takes the current model run and a quantity that can be a scalar or list, and if the quantity is a list it returns quantity[model run]. I'd like to have this method accessible throughout CELAVI (by the DES, Component, and PylcaCelavi modules) so we can more easily implement array-based uncertainty in parameters other than costs. Where do you recommend I locate this method so it's accessible everywhere? I first tried defining the method in scenario.py but got a circular import error.