### PR TITLE
Updates documentation and location of apply_array_uncertainty

### DIFF
--- a/celavi/component.py
+++ b/celavi/component.py
@@ -1,7 +1,12 @@
 from typing import Deque, Tuple, Dict
 from collections import deque
 
-from celavi.scenario import apply_array_uncertainty
+def apply_array_uncertainty(quantity, run):
+    """Use model run number to access one element in a parameter list."""
+    if not isinstance(quantity, list):
+        return float(quantity)
+    else:
+        return float(quantity[run])
 
 
 class Component:

--- a/celavi/component.py
+++ b/celavi/component.py
@@ -1,12 +1,7 @@
 from typing import Deque, Tuple, Dict
 from collections import deque
 
-def apply_array_uncertainty(quantity, run):
-    """Use model run number to access one element in a parameter list."""
-    if not isinstance(quantity, list):
-        return float(quantity)
-    else:
-        return float(quantity[run])
+from celavi.uncertainty_methods import apply_array_uncertainty
 
 
 class Component:

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -8,7 +8,7 @@ from networkx_query import search_nodes
 
 from celavi.costmethods import CostMethods
 
-
+import pdb
 class CostGraph:
     """
     Reads in supply chain data, creates a network of processing steps and facilities
@@ -305,18 +305,20 @@ class CostGraph:
             )
 
             for i in self.sc_end:
+                _dest = [key for key, value in subdict.items() if i in key]
                 _crit = [value for key, value in subdict.items() if i in key]
                 if len(_crit) > 0:
                     self.pathway_crit_history.append(
                         {
                             "year": self.year,
-                            "facility_id": _fac_id,
+                            "source_facility_id": _fac_id,
+                            "destination_facility_id": _dest,
                             "region_id_1": _loc_line.region_id_1.values[0],
                             "region_id_2": _loc_line.region_id_2.values[0],
                             "region_id_3": _loc_line.region_id_3.values[0],
                             "region_id_4": _loc_line.region_id_4.values[0],
                             "eol_pathway_type": i,
-                            "eol_pathway_criterion": min(_crit),
+                            "eol_pathway_criterion": _crit,
                             "bol_pathway_criterion": _bol_crit,
                         }
                     )
@@ -1043,9 +1045,13 @@ class CostGraph:
         Performs postprocessing on CostGraph outputs being saved to file and
         saves to user-specified filenames and directories
         """
-        _out = pd.DataFrame(self.pathway_crit_history).drop_duplicates(
-            ignore_index=True
-        )
+        _out = pd.DataFrame(
+            self.pathway_crit_history
+            ).explode(
+                column=['destination_facility_id','eol_pathway_criterion']
+                ).drop_duplicates(
+                    ignore_index=True
+                    )
         _out["run"] = self.run
         with open(self.pathway_crit_history_filename, "a") as f:
             _out.to_csv(

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -8,7 +8,7 @@ from networkx_query import search_nodes
 
 from celavi.costmethods import CostMethods
 
-import pdb
+
 class CostGraph:
     """
     Reads in supply chain data, creates a network of processing steps and facilities

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -4,12 +4,7 @@ import warnings
 
 from typing import Dict
 
-def apply_array_uncertainty(quantity, run):
-    """Use model run number to access one element in a parameter list."""
-    if not isinstance(quantity, list):
-        return float(quantity)
-    else:
-        return float(quantity[run])
+from celavi.uncertainty_methods import apply_array_uncertainty
 
 class CostMethods:
     """

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -6,6 +6,7 @@ from typing import Dict
 
 from celavi.uncertainty_methods import apply_array_uncertainty
 
+
 class CostMethods:
     """
     Functions for calculating processing and transportation costs throughout
@@ -78,24 +79,18 @@ class CostMethods:
             _scale = path_dict['cost uncertainty']['landfilling']['scale']
             return st.triang.rvs(c=_c,loc=_loc*_fee,scale=_scale*_fee, random_state=self.seed)
         elif path_dict['cost uncertainty']['landfilling']['uncertainty'] == 'array':
-            # in post-2020 (last historical data point)
-            if _year >= 2021:
-                # use an array of parameter values from config
-                # model run is the index
-                # parse as float value (defaults to string)
-                _m = apply_array_uncertainty(
-                    path_dict['cost uncertainty']['landfilling']['m'],
-                    self.run
-                    )
-                _b = apply_array_uncertainty(
-                    path_dict['cost uncertainty']['landfilling']['b'],
-                    self.run
-                    )
-                # fee model = point-slope form of a line
-                return _m * (_year - 2020.0) + _b
-            else:
-                # if the year is 2020 or earlier, just return the historical model
-                return _fee
+            # use an array of parameter values from config
+            # model run is the index
+            _m = apply_array_uncertainty(
+                path_dict['cost uncertainty']['landfilling']['m'],
+                self.run
+                )
+            _b = apply_array_uncertainty(
+                path_dict['cost uncertainty']['landfilling']['b'],
+                self.run
+                )
+            # fee model = point-slope form of a line
+            return _m * (_year - 2000.0) + _b
         else:
             return _fee
 
@@ -133,18 +128,15 @@ class CostMethods:
             _scale = path_dict['cost uncertainty']['rotor teardown']['scale']
             return st.triang.rvs(c=_c, loc=_loc*_cost, scale=_scale*_cost, random_state=self.seed) / _mass
         elif path_dict['cost uncertainty']['rotor teardown']['uncertainty'] == 'array':
-            if _year >= 2021:
-                _m = apply_array_uncertainty(
-                    path_dict['cost uncertainty']['rotor teardown']['m'],
-                    self.run
-                    )
-                _b = apply_array_uncertainty(
-                    path_dict['cost uncertainty']['rotor teardown']['b'],
-                    self.run
-                    )
-                return (_m * (_year - 2020.0)  + _b) / _mass
-            else:
-                return _cost / _mass
+            _m = apply_array_uncertainty(
+                path_dict['cost uncertainty']['rotor teardown']['m'],
+                self.run
+                )
+            _b = apply_array_uncertainty(
+                path_dict['cost uncertainty']['rotor teardown']['b'],
+                self.run
+                )
+            return (_m * (_year - 2000.0)  + _b) / _mass
         else:
             return _cost / _mass
 
@@ -167,7 +159,6 @@ class CostMethods:
             Cost (USD/metric ton) of cutting a turbine blade into 30-m segments
         """
         _cost = 27.56
-        _year = path_dict['year']
 
         if path_dict['cost uncertainty']['segmenting']['uncertainty'] == 'random':
             _c = path_dict['cost uncertainty']['segmenting']['c']
@@ -175,13 +166,10 @@ class CostMethods:
             _scale = path_dict['cost uncertainty']['segmenting']['scale']
             return st.triang.rvs(c=_c, loc=_loc*_cost, scale=_scale*_cost, random_state=self.seed)
         elif path_dict['cost uncertainty']['segmenting']['uncertainty'] == 'array':
-            if _year >= 2021:
-                return apply_array_uncertainty(
-                    path_dict['cost uncertainty']['segmenting']['b'],
-                    self.run
-                    )
-            else:
-                return _cost
+            return apply_array_uncertainty(
+                path_dict['cost uncertainty']['segmenting']['b'],
+                self.run
+                )
         else:
             return _cost
 
@@ -575,20 +563,17 @@ class CostMethods:
             return 0.0
         else:
             if path_dict['cost uncertainty']['shred transpo']['uncertainty'] == 'array':
-                if _year >= 2021.0:
-                    _m = apply_array_uncertainty(
-                        path_dict['cost uncertainty']['shred transpo']['m'],
-                        self.run
-                        )
-                    _b = apply_array_uncertainty(
-                        path_dict['cost uncertainty']['shred transpo']['b'],
-                        self.run
-                        )
-                    return (_m * (_year - 2020.0) + _b) * _vkmt
-                else:
-                    return _cost * _vkmt
-
-            if path_dict['cost uncertainty']['shred transpo'] == 'random':
+                _m = apply_array_uncertainty(
+                    path_dict['cost uncertainty']['shred transpo']['m'],
+                    self.run
+                    )
+                _b = apply_array_uncertainty(
+                    path_dict['cost uncertainty']['shred transpo']['b'],
+                    self.run
+                    )
+                print(f"Year {_year}, shred transpo {_m * (_year - 2000.0) + _b}")
+                return (_m * (_year - 2000.0) + _b) * _vkmt
+            elif path_dict['cost uncertainty']['shred transpo'] == 'random':
                 _c = path_dict['cost uncertainty']['shred transpo']['c']
                 _loc = path_dict['cost uncertainty']['shred transpo']['loc']
                 _scale = path_dict['cost uncertainty']['shred transpo']['scale']

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -3,7 +3,13 @@ import scipy.stats as st
 import warnings
 
 from typing import Dict
-from celavi.scenario import apply_array_uncertainty
+
+def apply_array_uncertainty(quantity, run):
+    """Use model run number to access one element in a parameter list."""
+    if not isinstance(quantity, list):
+        return float(quantity)
+    else:
+        return float(quantity[run])
 
 class CostMethods:
     """

--- a/celavi/costmethods.py
+++ b/celavi/costmethods.py
@@ -571,7 +571,6 @@ class CostMethods:
                     path_dict['cost uncertainty']['shred transpo']['b'],
                     self.run
                     )
-                print(f"Year {_year}, shred transpo {_m * (_year - 2000.0) + _b}")
                 return (_m * (_year - 2000.0) + _b) * _vkmt
             elif path_dict['cost uncertainty']['shred transpo'] == 'random':
                 _c = path_dict['cost uncertainty']['shred transpo']['c']

--- a/celavi/reeds_importer.py
+++ b/celavi/reeds_importer.py
@@ -4,8 +4,8 @@ class ReedsImporter:
     """    
     The ReedsImporter class 
 
-    - Provides an object which stores the files names required for modifying ReEDS output datasets 
-    for compatibility with pyLCIA.
+    - Provides an object which stores the files names required for modifying ReEDS
+      output datasets for compatibility with pyLCIA.
     - Calls the data manipulation methods.
 
     Parameters

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -15,6 +15,7 @@ import pandas as pd
 from scipy.stats import weibull_min
 
 from celavi.routing import Router
+from celavi.uncertainty_methods import apply_array_uncertainty
 from celavi.costgraph import CostGraph
 from celavi.compute_locations import ComputeLocations
 from celavi.data_filtering import filter_locations, filter_routes
@@ -23,12 +24,6 @@ from celavi.reeds_importer import ReedsImporter
 from celavi.des import Context
 from celavi.diagnostic_viz import DiagnosticViz
 
-def apply_array_uncertainty(quantity, run):
-    """Use model run number to access one element in a parameter list."""
-    if not isinstance(quantity, list):
-        return float(quantity)
-    else:
-        return float(quantity[run])
 
 class Scenario:
     """

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -14,13 +14,6 @@ import pandas as pd
 
 from scipy.stats import weibull_min
 
-def apply_array_uncertainty(quantity, run):
-    """Use model run number to access one element in a parameter list."""
-    if not isinstance(quantity, list):
-        return float(quantity)
-    else:
-        return float(quantity[run])
-
 from celavi.routing import Router
 from celavi.costgraph import CostGraph
 from celavi.compute_locations import ComputeLocations
@@ -30,6 +23,12 @@ from celavi.reeds_importer import ReedsImporter
 from celavi.des import Context
 from celavi.diagnostic_viz import DiagnosticViz
 
+def apply_array_uncertainty(quantity, run):
+    """Use model run number to access one element in a parameter list."""
+    if not isinstance(quantity, list):
+        return float(quantity)
+    else:
+        return float(quantity[run])
 
 class Scenario:
     """

--- a/celavi/uncertainty_methods.py
+++ b/celavi/uncertainty_methods.py
@@ -1,0 +1,6 @@
+def apply_array_uncertainty(quantity, run):
+    """Use model run number to access one element in a parameter list."""
+    if not isinstance(quantity, list):
+        return float(quantity)
+    else:
+        return float(quantity[run])

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,8 +15,8 @@ import sys
 import sphinx_rtd_theme
 
 sys.path.insert(0, os.path.abspath(".."))
-sys.path.insert(0, os.path.abspath("../celavi/"))
-sys.path.insert(0, os.path.abspath("../celavi/pylca_celavi/"))
+sys.path.insert(1, os.path.abspath("../celavi/"))
+sys.path.insert(2, os.path.abspath("../celavi/pylca_celavi/"))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/doc_config.rst
+++ b/docs/doc_config.rst
@@ -168,7 +168,7 @@ Scenario Flags
 The set of Boolean flags at the top of the scenario configuration file control much of the preprocessing done to set up a CELAVI simulation. Additional explanations for each flag are provided here.
 
 * `clear_results`
-    * When CELAVI is executed multiple times on the same machine, it will produce one or more sets of output files in the `results` directory (one set of results files is produced per model run). Set `clear_results` to True if you expect to be executing CELAVI more than once and do not want the results of each execution to be overwritten.
+	* When CELAVI is executed multiple times on the same machine, it will produce one or more sets of output files in the `results` directory (one set of results files is produced per model run). Set `clear_results` to True if you expect to be executing CELAVI more than once and do not want the results of each execution to be overwritten.
 	* Results from the most recent CELAVI execution are always found in the `results` directory.
 	* When `clear_results` is True, every CELAVI execution after the first one will produce an additional directory of results files, with "results-" and the current timestamp in the directory name. The contents of the new `results` directory is the output files from the *previous* CELAVI execution.
 * `compute_locations`

--- a/docs/doc_config.rst
+++ b/docs/doc_config.rst
@@ -162,6 +162,50 @@ The `cost uncertainty` dictionary (an element of the `circular_pathways` diction
 		component_weibull_params:  # Dictionary with Weibull distribution parameters (L, K) of each component lifetime.
 		substitution_rates:        # Dictionary of materials substituted by circular components/materials and the substitution rates (kg/kg).
 
+Scenario Flags
+^^^^^^^^^^^^^^
+
+The set of Boolean flags at the top of the scenario configuration file control much of the preprocessing done to set up a CELAVI simulation. Additional explanations for each flag are provided here.
+
+* `clear_results`
+    * When CELAVI is executed multiple times on the same machine, it will produce one or more sets of output files in the `results` directory (one set of results files is produced per model run). Set `clear_results` to True if you expect to be executing CELAVI more than once and do not want the results of each execution to be overwritten.
+	* Results from the most recent CELAVI execution are always found in the `results` directory.
+	* When `clear_results` is True, every CELAVI execution after the first one will produce an additional directory of results files, with "results-" and the current timestamp in the directory name. The contents of the new `results` directory is the output files from the *previous* CELAVI execution.
+* `compute_locations`
+	* This flag controls whether the facility location and type dataset is assembled from raw location files before supply chain routes are found or the simulation begins.
+	* If you have already manually assembled the facility location and type dataset for your supply chain, then this flag can be set to False. However, if the facility information to be used in your supply chain is coming from a database such as the U.S. Wind Turbine Database or the Landfill Methane Outreach Program, then setting `compute_locations` to True will assemble the complete facility dataset.
+* `run_routes`
+	* When `run_routes` is True, then the facility locations and route pairs datasets will be used to identify pairs of facilities between which materials will be transported. The `Router` module is then used to calculate minimum-distance (on-road) routes between each facility pair.
+	* Generating routes for a multi-state or national supply chain can be time consuming, depending on the number of facilities in a supply chain. If the underlying facility locations dataset is stable, then `run_routes` need be True only for one CELAVI execution. Future executions will use the same set of routes and there is no need to re-generate the routes dataset.
+* `use_computed_routes`
+	* The user can bypass the built-in Router module and supply a custom routes dataset by setting `use_computed_routes` to False. In this case, the filename with the custom routes dataset must also be provided in the Case Study configuration file.
+	* If `run_routes` is True, then `use_computed_routes` should also generally be True, unless the user is comparing results from two different routes datasets.
+* `initialize_costgraph`
+	* The Cost Graph model is initialized from the facility locations dataset, the routes dataset, and several other datasets that define how facilities in the supply chain are interconnected.
+	* While initializing the Cost Graph can be time consuming, it is recommended to keep `initialize_costgraph` set to True unless CELAVI is being executed with one model run per simulation and no changes in the input datasets or parameters are being made between executions.
+	* When executing multiple runs per scenario, the Cost Graph model will only be initialized once, thus `initialize_costgraph` should be True in this case.
+* `location_filtering`
+	* This flag can be used in combination with the `states_included` list under the `scenario` dictionary to filter down large input datasets to include only certain U.S. states (region_id_2, in the input datasets). One set of (for example) national-scale data can then be defined and filtered as needed, rather than developing separate datasets.
+	* If `location_filtering` is True but there are no states listed under `states_included`, then a warning is printed and no filtering is performed. If `location_filtering` is False, then no filtering is performed even if states are listed under `states_included`.
+	* Both the processed facility locations dataset and the routes dataset are filtered with this flag.
+* `distance_filtering`
+	* When `distance_filtering` is True, the route pairs dataset is used to filter down the routes file and Cost Graph edges based on the `vkmt_max` column. This allows users to set a transportation distance limit, for instance for transportation to landfills, without having to manually remove unrealistically lengthy routes.
+	* Some care should be taken in using `distance_filtering` and in setting the `vkmt_max` values. It's possible to filter out routes that must be included for the supply chain to be complete (e.g. routes to a power plant from a manufacturing facility), and in this case the filtering will produce an error during the CELAVI execution.
+	* Any blank values in the `vkmt_max` column will be backfilled with a sufficiently large number that no routes will be filtered out, allowing for only routes between specific facility pairs to be filtered based on distance.
+* `pickle_costgraph`
+	* When True, the `pickle_costgraph` flag will save (pickle) a copy of the initialized Cost Graph model as a Python object that can be examine or used outside the CELAVI execution. This can be useful for multiple repeated CELAVI executions.
+* `generate_step_costs`
+	* The step costs dataset assigns processing cost methods (models) to every facility in the supply chain. Depending on how the processing costs vary with space and with facility, users may want to manually generate the step costs dataset or generate it automatically by setting `generate_step_costs` to True.
+	* If this flag is True, the assumption is that processing costs *do not vary with facility location*, and more broadly that there is one (set of) processing cost methods per facility type. In the case that there are multiple processing cost methods for a single facility type - for instance, separate landfill tipping fee models by U.S. state or county - then `generate_step_costs` must be set to False and the step costs dataset generated manually.
+* `use_fixed_lifetime`
+	* Technology components remain "in use" for a period of time before entering the end-of-life phase. The time "in use" is the component lifetime, which for each component type can be modeled either as a fixed value or as random draws from a Weibull distribution. Both the fixed values and the Weibull parameters are defined by component type in the Scenario configuration file.
+	* Set `use_fixed_lifetime` to True to use a fixed, deterministic lifetime for every technology component, or set to False to generate lifetimes from the Weibull distributions.
+	* If `use_fixed_lifetime` is set to False, it is recommended that users also set the `seed` value under the `scenario` dictionary. This will generate stochastic results that are reproducible in repeated CELAVI executions.
+* `use_lcia_shortcut`
+	* Repeatedly performing LCIA calculations can lengthen CELAVI run time considerably. To speed up the calculations, `use_lcia_shortcut` can be set to True to use precomputed emission factors stored in a local file. If this file does not yet exist, then LCIA calculations are performed normally and the file is populated with emission factors as they are calculated.
+	* When performing multiple model runs in a single CELAVI execution, it is strongly recommended to set `use_lcia_shortcut` to True to shorten the run time.
+	* After changes to the scenario parameters or to the input datasets, it is recommended to delete the local emission factors file to avoid using incorrect factors.
+
 
 Case Study Config Example
 -------------------------

--- a/docs/doc_des.rst
+++ b/docs/doc_des.rst
@@ -3,8 +3,8 @@ Discrete Event Simulation
 
 The discrete event simulation (DES) consists of:
 
-* A **Context** instance which stores supply-chain-level information and methods
-* Many **Component** instances that transition through the supply chain during the simulation
+* A **Context** instance which stores supply-chain-level information and methods.
+* Many **Component** instances that transition through the supply chain during the simulation.
 * A **Facility Inventory** for every facility in the supply chain: this inventory records material flows.
 * A **Transportation Tracker** for every facility in the supply chain with *inbound* material flows.
 

--- a/docs/doc_preprocessing.rst
+++ b/docs/doc_preprocessing.rst
@@ -1,14 +1,20 @@
 Data Preprocessing
 ==================
 
+Classes documented here deal with processing raw information into CELAVI-ready input datasets. Depending on the data source used, methods within the Compute Locations class may need to be edited or new methods added, to work with the different formats of the raw information.
+
 Data Manager
 ------------
+
+The `Data` class and its child classes define specific data formats (column names) and data types for the CELAVI input datasets. Backfilling can also be performed, or not, for each dataset type.
 
 .. automodule:: celavi.data_manager
     :members:
 
 Compute Locations
 -----------------
+
+Methods in this class perform merging and filtering operations to generate one dataset of all supply chain facility locations and types, and a second dataset of technology unit installations over time.
 
 .. automodule:: celavi.compute_locations
     :members:
@@ -17,12 +23,16 @@ Compute Locations
 Data Filtering
 --------------
 
+The Data Filtering methods produce subsets of the facility locations, technology unit installation, and routes datasets (all outputs of preprocessing methods documented here) by U.S. state (region_id_2) and/or by the distance between facility pairs.
+
 .. automodule:: celavi.data_filtering
     :members:
 
 
 Router
 ------
+
+Router methods implement the Djikstra minimum-distance algorithm to find on-road transportation routes between supply chain facility pairs.
 
 .. automodule:: celavi.routing
     :members:

--- a/docs/doc_scenario.rst
+++ b/docs/doc_scenario.rst
@@ -3,7 +3,7 @@ Scenario
 
 The Scenario class initializes a simulation for a single set of parameters and then executes a user-specified number of uncertainty runs within that scenario.
 
-The DES, Cost Graph, and PyLCIA are all instantiated and called from Scenario, as is postprocessing and diagnostic visualizations.
+The DES, Cost Graph, and PyLCIA are all instantiated and called from Scenario, as are postprocessing methods and the diagnostic visualizations.
 
 .. automodule:: celavi.scenario
     :members:


### PR DESCRIPTION
This started as a simple documentation update but now includes:

- Relocation of `apply_array_uncertainty` to its own .py file and updated import statements in scenario.py, costgraph.py, costmethods.py, and component.py.
- Expansion of the pathway criterion history output file to include all cost options instead of the minimum by pathway. Expanded explanation and a portion of the updated file is in a comment below. @akey7 Can you review the new file format and let me know if you think it will cause issues with visualization and/or aggregation? 