### PR TITLE
Adds complete stochastic uncertainty capabilities to CostMethods with supporting changes elsewhere

### DIFF
--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -32,6 +32,7 @@ class CostGraph:
         sc_in_circ : List[str]=[],
         sc_out_circ : List[str]=[],
         year: float = 2000.0,
+        start_year: float = 2000.0,
         verbose: int = 0,
         save_copy=False,
         save_name="netw.csv",
@@ -78,6 +79,8 @@ class CostGraph:
             Facility type(s) that process material for re-circulation outside the supply chain
         year : float
             Simulation year provided by the DES at CostGraph instantiation.
+        start_year : float
+            Year at beginning of the model run.
         verbose : int
             Integer specifying how much info CostGraph should provide as it
             works.
@@ -95,7 +98,7 @@ class CostGraph:
         random_state : np.random.default_rng
             Instantiated random number generator for uncertainty analysis.
         """
-        self.cost_methods = CostMethods(seed=random_state, run=run)
+        self.cost_methods = CostMethods(start_year = start_year, seed=random_state, run=run)
 
         self.start_time = time()
         self.step_costs = pd.read_csv(step_costs_file)

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -6,7 +6,6 @@ Created January 27, 2022.
 from dataclasses import replace
 import re
 import os
-import sys
 import time
 import yaml
 import pickle
@@ -259,6 +258,7 @@ class Scenario:
                 sc_in_circ=self.scen["circular_pathways"].get("sc_in_circ", []),
                 sc_out_circ=self.scen["circular_pathways"].get("sc_out_circ", []),
                 year=start_year,
+                start_year=start_year,
                 verbose=self.case["model_run"].get("cg_verbose", 1),
                 save_copy=self.case["model_run"].get("save_cg_csv", True),
                 save_name=self.files["costgraph_csv"],
@@ -348,6 +348,7 @@ class Scenario:
             self.netw.path_dict["component mass"] = component_total_mass.loc[
                 component_total_mass.year == start_year, "mass_tonnes"
             ].values[0]
+            self.netw.update_costs(self.netw.path_dict)
             self.netw.pathway_crit_history = list()
 
             self.lca.run = self.run

--- a/celavi/uncertainty_methods.py
+++ b/celavi/uncertainty_methods.py
@@ -1,6 +1,26 @@
+import scipy.stats as st
+
 def apply_array_uncertainty(quantity, run):
     """Use model run number to access one element in a parameter list."""
-    if not isinstance(quantity, list):
-        return float(quantity)
-    else:
+    if isinstance(quantity, list):
         return float(quantity[run])
+    elif isinstance(quantity,dict):
+        return float(quantity['value'])
+    else:
+        return float(quantity)
+
+def apply_stoch_uncertainty(quantity, seed=1, distn=st.triang):
+    """Draw from distribution if parameters exist."""
+    if isinstance(quantity, dict):
+        # return the parameter value drawn from a distribution
+        if all([i in quantity.keys() for i in ['c', 'loc', 'scale']]):
+            return distn.rvs(c=quantity['c'],
+                            loc=quantity['loc'],
+                            scale=quantity['scale'],
+                            random_state=seed
+                            )
+        else:
+            return quantity['value']
+    else:
+        # return the parameter value in the config file
+        return float(quantity)


### PR DESCRIPTION
# How the CostMethods worked before

* Cost models/methods could be run with no uncertainty, array-based uncertainty using specific values from the scenario YAML file, or stochastic uncertainty using draws from a probability distribution. Parameters can have either no uncertainty or uncertainty within a scenario, so we can explore results variability due to one parameter, a subset of all our parameters, or every parameter. Uncertain parameters within a scenario must all have either array or stochastic uncertainty.
* When the stochastic uncertainty was used, triangular distributions were defined for uncertain parameters and random draws from these distributions were taken every time the cost method was called.
* This is undesirable behavior because we're examining the impact of particular cost method parameters (slope/rate of change and y-intercept/initial value, mostly), and taking draws at every time step doesn't give us coherent cost trends and therefore doesn't give us coherent insight.

# How the CostMethods will work following this PR

* When using stochastic uncertainty, a single draw from a parameter's probability distribution is taken at the *beginning* of each model run (at year 2000) and used throughout that run. Subsequent runs will use additional draws from the distribution, one draw per run.
* The array-based uncertainty capability has not changed. The previously developed "[x]_[param]_oaat" scenario YAMLs will still work with this code. I updated the format for all 20 OAAT YAMLs on OneDrive and tested this PR on the updated 10_fgic_oaat with no errors and expected results. The YAML format updates involved removing the probability distribution parameters, which weren't being used in the OAAT analysis anyway.
* The no uncertainty capabilities are unchanged save for format updates to the scenario YAML - see below.

# Data and config changes to support this PR

* No changes to the input datasets or files.
* No changes required to the case study YAML.
* The `cost_uncertainty` dictionary in the scenario YAML file changed format to allow for stochastic capabilities.
* A scenario YAML for executing 10 stochastic runs on the tiny data set is below, and also stored as a separate file in OneDrive under uncertainty/stochastic-yamls
* See the `stochastic-uncertainty` branch in the data repo for an updated scenario YAML file that executes a baseline (MCiC-MC) run using this new format. I'll merge those changes in to all our stable data branches after this PR is merged in.

## Stochastic scenario YAML for use with tiny data
```
flags:
  clear_results         : True # If results files already exist, move them to a sub-directory to avoid overwriting
  compute_locations     : True  # if compute_locations is enabled (True), compute locations from raw input files (e.g., LMOP, US Wind Turbine Database)
  run_routes            : True  # if run_routes is enabled (True), compute routing distances between all input locations
  use_computed_routes   : True  # if use_computed_routes is enabled, read in a pre-assembled routes file instead of generating a new one
  initialize_costgraph  : True  # create cost graph fresh or use an imported version
  location_filtering    : False  # If true, dataset will be filtered to the states below
  distance_filtering    : False # if true, filter computed routes based on max distances in route_pairs file
  pickle_costgraph      : True  # save the newly initialized costgraph as a pickle file
  generate_step_costs   : True # set to False if supply chain costs for a facility type vary regionally
  use_fixed_lifetime    : True # set to False to use Weibull distribution for lifetimes
  use_lcia_shortcut     : True # set to False to re-generate the lca_db file
  

scenario:
    name: Tiny Stochastic Test
    capacity_projection: StScen20A_Fake_annual_state.csv
    states_included:
    seed: 13
    electricity_mix_level : state
    runs: 10

circular_pathways:
    sc_begin:
    - manufacturing
    sc_end: 
    - landfilling
    #sc_in_circ:
    sc_out_circ:
    - cement co-processing
    - next use
    learning:
        coarse grinding:
            component : blade
            uncertainty: 
            initial cumul: 1.0
            cumul: 
            learn rate: -0.05
            steps:
            - coarse grinding
            - coarse grinding onsite
        fine grinding:
            component : blade
            uncertainty:
            initial cumul: 1.0
            cumul: 
            learn rate: -0.05
            steps:
            - fine grinding
    cost uncertainty:
        landfilling:
            uncertainty: stochastic
            m:
                value: 1.5921
            b:
                c: 0.5
                loc: 23.12
                scale: 11.56
                value: 
        rotor teardown:
            uncertainty:
            m: 1467.08
            b: 285.0
        segmenting: 
            uncertainty:
            b: 27.56
        coarse grinding onsite:
            uncertainty: stochastic
            initial cost:
                c: 0.5
                loc: 53
                scale: 106
                value: 
        coarse grinding: 
            uncertainty: stochastic
            initial cost:
                c: 0.5
                loc: 53
                scale: 106
                value: 
        fine grinding: 
            uncertainty: stochastic
            initial cost:
                c: 0.5
                loc: 71.5
                scale: 143
                value: 
            revenue:
                c: 0.5
                loc: 136.5
                scale: 273
                value: 
        coprocessing:
            uncertainty:
            b: 10.37
        segment transpo:
            uncertainty: stochastic
            cost 1:  # Before 2001; 2002-2003
                c: 0.5
                loc: 2.175
                scale: 4.35
                value: 
            cost 2:  # 2001-2002; 2003-2019
                c: 0.5
                loc: 4.35
                scale: 8.70
                value: 
            cost 3:  # 2019-2031
                c: 0.5
                loc: 6.525
                scale: 13.05
                value: 
            cost 4:  # 2031-2044
                c: 0.5
                loc: 8.7
                scale: 17.40
                value: 
            cost 5:  # 2044-2050
                c: 0.5
                loc: 10.875
                scale: 21.75
                value: 
        shred transpo:
            uncertainty: stochastic
            m: 
                c: 0.5
                loc: 0.00056105
                scale: 0.0011221
                value: 
            b: 
                c: 0.5
                loc: 0.0262
                scale: 0.0524
                value: 
        manufacturing:
            uncertainty:
            b: 11440.0
    path_split:
        fine grinding:
            fraction: 
                value: 0.3
            facility_1: landfilling
            facility_2: next use  
        pass:
            next use
    permanent_lifespan_facility: 
    - landfilling
    - cement co-processing
    - next use
    vkmt : 
    component mass : 
    year : 
    

technology_components:
    circular_components:
    - blade
    component_list:
        nacelle : 1
        blade : 3
        tower : 1
        foundation : 1
    component_materials:
        nacelle : 
        - steel
        blade : 
        - glass fiber
        - epoxy
        tower : 
        - steel
        foundation : 
        - concrete
    component_fixed_lifetimes: # Years
        nacelle : 30
        blade : 20
        foundation : 50
        tower : 50
    component_weibull_params: #L, K
        nacelle : 
        blade : 
            L : 240
            K : 2.2
        foundation : 
        tower :
    substitution_rates:
        sand: 0.15
        coal: 0.30
```