### PR TITLE
Issue 266: refactor supply chain structure input datasets and various speed ups

### DIFF
--- a/celavi/compute_locations.py
+++ b/celavi/compute_locations.py
@@ -987,10 +987,12 @@ class ComputeLocations:
 
         # exclude Hawaii, Guam, Puerto Rico, and Alaska
         # (only have road network data for the contiguous United States)
+        # DC has no landfills in the landfill MOP data
         locations = locations[locations.region_id_2 != 'GU']
         locations = locations[locations.region_id_2 != 'HI']
         locations = locations[locations.region_id_2 != 'PR']
         locations = locations[locations.region_id_2 != 'AK']
+        locations = locations[locations.region_id_2 != 'DC']
         
         locations = locations[locations.region_id_3 != 'Nantucket']
 

--- a/celavi/compute_locations.py
+++ b/celavi/compute_locations.py
@@ -281,7 +281,7 @@ class ComputeLocations:
 
         # exclude Hawaii, Guam, Puerto Rico, and Alaska (only have road network data for the contiguous United States)
         pv_locs.drop(
-            index = pv_locs[pv_locs.region_id_2.isin(['HI','GU','PR','AK'])].index,
+            index = pv_locs[pv_locs.region_id_2.isin(['HI','GU','PR','AK', 'DC'])].index,
             inplace = True
         )
 
@@ -386,7 +386,7 @@ class ComputeLocations:
 
         # exclude Hawaii, Guam, Puerto Rico, and Alaska (only have road network data for the contiguous United States)
         building_locs.drop(
-            index = building_locs[building_locs.region_id_2.isin(['HI','GU','PR','AK'])].index,
+            index = building_locs[building_locs.region_id_2.isin(['HI','GU','PR','AK', 'DC'])].index,
             inplace = True
         )
 

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -8,7 +8,7 @@ from networkx_query import search_nodes
 
 from celavi.costmethods import CostMethods
 
-
+import pdb
 class CostGraph:
     """
     Reads in supply chain data, creates a network of processing steps and facilities
@@ -561,6 +561,20 @@ class CostGraph:
         ]
 
         self.supply_chain.add_edges_from(all_edge_list)
+        
+        # Each node needs a facility_id attribute assigned
+        # This is so pathfinding logic, which operates off facility_id, will work
+        # the facility_id is the numeric code prepended by one letter, and it's already
+        # a part of the node_id
+        _node_attr_dict = {}
+        for node_id, facility_id in zip(self.network_data.u_node_id, self.network_data.u_facility_id):
+            if node_id not in _node_attr_dict.keys(): _node_attr_dict[node_id] = facility_id
+
+        nx.set_node_attributes(
+            self.supply_chain,
+            values = _node_attr_dict,
+            name = 'facility_id'
+        )
 
         if self.verbose > 0:
             print(f'CostGraph: Adding nodes and edges took {np.round((time() - _netime)/60, 2)} minutes',flush=True)

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -623,10 +623,11 @@ class CostGraph:
             print(f'CostGraph: Calculating edge costs took {np.round((time() - _ctime)/60, 2)} minutes', flush=True)
 
         _cost_adjust = min([value for key, value in nx.get_edge_attributes(self.supply_chain, 'cost').items()])
-        self.cost_adjustment_factor[self.year] = abs(_cost_adjust) if _cost_adjust < 0.0 else 0.0
-
-        for edge in self.supply_chain.edges():
-            self.supply_chain.edges[edge]['cost'] = self.supply_chain.edges[edge]['cost'] + self.cost_adjustment_factor[self.year]
+        if _cost_adjust < 0.0:
+            print(f'CostGraph: Adjusting all costs for {self.year} upwards by \${np.round(_cost_adjust, 2)}', flush = True)
+            self.cost_adjustment_factor[self.year] = abs(_cost_adjust) if _cost_adjust < 0.0 else 0.0
+            for edge in self.supply_chain.edges():
+                self.supply_chain.edges[edge]['cost'] = self.supply_chain.edges[edge]['cost'] + self.cost_adjustment_factor[self.year]
 
         if self.verbose > 0:
             print(f'CostGraph: Instantiation took {np.round((time() - self.start_time)/60, 2)} minutes', flush = True)
@@ -947,13 +948,16 @@ class CostGraph:
             )
         
         _cost_adjust = min([value for key, value in nx.get_edge_attributes(self.supply_chain, 'cost').items()])
-        self.cost_adjustment_factor[self.year] = abs(_cost_adjust) if _cost_adjust < 0.0 else 0.0
+        if _cost_adjust < 0.0:
+            print(f'CostGraph.update_costs: Adjusting all costs for {self.year} upwards by \${np.round(_cost_adjust, 2)}',
+            flush = True)
+            self.cost_adjustment_factor[self.year] = abs(_cost_adjust) if _cost_adjust < 0.0 else 0.0
 
-        for edge in self.supply_chain.edges():
-            self.supply_chain.edges[edge]['cost'] = self.cost_adjustment_factor[self.year] + self.supply_chain.edges[edge]['cost']
+            for edge in self.supply_chain.edges():
+                self.supply_chain.edges[edge]['cost'] = self.cost_adjustment_factor[self.year] + self.supply_chain.edges[edge]['cost']
 
         if self.verbose > 0 and self.year > 2001:
-            print(f'CostGraph: Costs updated for {self.year} after {np.round(time() - self.update_time, 1)} s',
+            print(f'CostGraph.update_costs: Costs updated for {self.year} after {np.round(time() - self.update_time, 1)} s',
                     flush=True)
         self.update_time = time()
 
@@ -976,4 +980,4 @@ class CostGraph:
                     f, mode="a", header=f.tell() == 0, index=False, lineterminator="\n"
                 )
         except KeyError:
-            print(f"CostGraph: pathway_crit_history is empty; no end of life flows were simulated")
+            print(f"CostGraph.save_costgraph_outputs: pathway_crit_history is empty; no end of life flows were simulated")

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -19,7 +19,6 @@ class CostGraph:
     def __init__(
         self,
         step_costs_file: str,
-        fac_edges_file: str,
         transpo_edges_file: str,
         locations_file: str,
         routes_file: str,
@@ -48,8 +47,6 @@ class CostGraph:
         step_costs_file : str
             Path to file listing processing steps and cost calculation methods
             by facility type.
-        fac_edges_file : str
-            Path to file listing intra-facility edges by facility type.
         transpo_edges_file : str
             Path to file listing inter-facility edges and transportation cost
             calculation methods.
@@ -102,7 +99,6 @@ class CostGraph:
 
         self.start_time = time()
         self.step_costs = pd.read_csv(step_costs_file)
-        self.fac_edges = pd.read_csv(fac_edges_file)
         self.transpo_edges = pd.read_csv(transpo_edges_file)
 
         # these data sets are processed line by line

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -115,9 +115,8 @@ class CostGraph:
         # find_nearest
         self.loc_df = pd.read_csv(locations_file)
 
-        self.sc_end = sc_end + sc_out_circ
-        self.sc_begin = sc_begin 
-        self.sc_reenter = sc_in_circ
+        self.sc_end = sc_end + sc_out_circ + sc_in_circ
+        self.sc_begin = sc_begin
         
         if len(circular_components) == 1:
             self.circular_components = circular_components[0]
@@ -294,12 +293,13 @@ class CostGraph:
         [2] list of nodes defining the path between source and the closest node
         """
         if self.verbose > 1:
-            print(f"Finding shortest paths from {source_node} to terminal nodes")
+            print(f"Finding shortest paths from {source_node} to {self.sc_end}")
 
         # Pull out a list of all nodes in the supply chain that are terminal
         # The linear supply chain terminates there, OR one loop of a circular pathway
         # terminates there
-        targets = [tnode for tnode in self.supply_chain.nodes if any([scr in tnode for scr in self.sc_reenter])]
+        targets = [tnode for tnode in self.supply_chain.nodes 
+                    if any([scr in tnode for scr in self.sc_end])]
 
         # Loop thru terminal nodes
         # Use the loop rather than list comprehension b/c if a terminal node isn't reachable from the source
@@ -315,11 +315,11 @@ class CostGraph:
             except nx.NetworkXNoPath:
                 if self.verbose > 1: print(f'CostGraph.find_nearest: No path from {source_node} to {tnode}')
                 continue
-        pdb.set_trace()
+        
         # return the smallest of all lengths to get to typeofnode
         if len(lengths) > 0:
             # For detailed debugging, save a file of all paths found and their lengths
-            pd.DataFrame([short_paths, lengths]).to_csv(f'{source_node}-{self.year}-paths.csv', index=False)
+            pd.DataFrame([short_paths, lengths]).to_csv(f'{source_node}-{int(self.year)}-paths.csv', index=False)
 
             # Print a summary of the paths found
             if self.verbose > 1:
@@ -329,10 +329,8 @@ class CostGraph:
 
             # dict of shortest paths to all targets
             nearest = min(lengths, key=lengths.get)
-            timeout = nx.get_node_attributes(self.supply_chain, "timeout")
-            timeout_list = [
-                value for key, value in timeout.items() if key in short_paths[nearest]
-            ]
+            timeout_list = [1.0 for node in short_paths[nearest]]
+
             dist_list = [
                 self.supply_chain.edges[short_paths[nearest][d : d + 2]]["dist"]
                 for d in range(len(short_paths[nearest]) - 1)
@@ -343,9 +341,8 @@ class CostGraph:
                 for d in range(len(short_paths[nearest]) - 1)
             ]
             route_id_list.insert(0, None)
-            _out = self.list_of_tuples(
-                short_paths[nearest], timeout_list, dist_list, route_id_list
-            )
+            
+            _out = self.list_of_tuples(short_paths[nearest], timeout_list, dist_list, route_id_list)
 
             # create dictionary for this preferred pathway cost and decision
             # criterion and append to the pathway_crit_history
@@ -358,7 +355,7 @@ class CostGraph:
             #    weight=crit,
             #    method="bellman-ford",
             #)
-
+            pdb.set_trace()
             for i in self.sc_end:
                 _dest = [key for key, value in lengths.items() if i in key]
                 _crit = [value for key, value in lengths.items() if i in key]
@@ -381,7 +378,7 @@ class CostGraph:
             return nearest, lengths[nearest], _out
         else:
             # not found, no path from source to typeofnode
-            print(f'CostGraph.find_nearest: No paths from {source_node} to any of {self.sc_reenter} nodes')
+            print(f'CostGraph.find_nearest: No paths from {source_node} to any of {self.sc_end} nodes')
             return None, None, None
 
 
@@ -436,10 +433,7 @@ class CostGraph:
         if lengths:
             # dict of shortest paths to all targets
             nearest = min(lengths, key=lengths.get)
-            timeout = nx.get_node_attributes(self.supply_chain, "timeout")
-            timeout_list = [
-                value for key, value in timeout.items() if key in short_paths[nearest]
-            ]
+            timeout_list = [1.0 for node in short_paths[nearest]]
             dist_list = [
                 self.supply_chain.edges[short_paths[nearest][d : d + 2]]["dist"]
                 for d in range(len(short_paths[nearest]) - 1)

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -505,61 +505,6 @@ class CostGraph:
 
         return _out
 
-    def get_nodes(self, facility_df: pd.DataFrame):
-        """
-        Generates a data structure that defines all nodes and node attributes
-        for a single facility.
-
-        Parameters
-        ----------
-        facility_df : pd.DataFrame
-            DataFrame containing unique facility IDs, processing steps, and
-            the name of the method (if any) used to calculate processing costs
-
-            Columns:
-                - facility_id : int
-                - step : str
-                - connects : str
-                - step_cost_method : str
-
-        Returns
-        -------
-        List[(str, Dict)]
-            Data structure used to define a networkx DiGraph. Attributes
-            (dictionary keys) are: processing step, cost method, facility
-            ID, and region identifiers.
-        """
-        if self.verbose > 1:
-            print(
-                "Getting nodes for facility ", str(facility_df["facility_id"].values[0])
-            )
-
-        _id = facility_df["facility_id"].values[0]
-
-        # list of nodes (processing steps) within a facility
-        _node_names = (
-            self.step_costs["step"].loc[self.step_costs.facility_id == _id].tolist()
-        )
-
-        # data frame matching facility processing steps with methods for cost
-        # calculation over time
-        _step_cost = self.step_costs[
-            ["step", "step_cost_method", "facility_id", "connects"]
-        ].loc[self.step_costs.facility_id == _id]
-
-        _step_cost["timeout"] = 1
-
-        # create list of dictionaries from data frame with processing steps,
-        # cost calculation method, and facility-specific region identifiers
-        _attr_data = _step_cost.merge(
-            facility_df, how="outer", on="facility_id"
-        ).to_dict(orient="records")
-
-        # reformat data into a list of tuples as (str, dict)
-        _nodes = self.list_of_tuples(self.get_node_names(_id, _node_names), _attr_data)
-
-        return _nodes
-
 
     def build_supplychain_graph(self):
         """
@@ -713,7 +658,7 @@ class CostGraph:
             _node = [
                 x
                 for x, y in self.supply_chain.nodes(data=True)
-                if (('facility_id',node_id) in y.items()) and (('connects','bid') in y.items())
+                if ('facility_id',node_id) in y.items()
             ][0]
 
         # Get a list of all nodes upstream of this node_id with a facility type

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -314,8 +314,9 @@ class CostGraph:
         
         # return the smallest of all lengths to get to typeofnode
         if len(lengths) > 0:
-            # For detailed debugging, save a file of all paths found and their lengths
-            pd.DataFrame([short_paths, lengths]).to_csv(f'{source_node}-{int(self.year)}-paths.csv', index=False)
+            if self.verbose > 1:
+                # For detailed debugging, save a file of all paths found and their lengths
+                pd.DataFrame([short_paths, lengths]).to_csv(f'{source_node}-findnearest-{int(self.year)}-paths.csv', index=False)
 
             # Print a summary of the paths found
             if self.verbose > 1:
@@ -426,10 +427,13 @@ class CostGraph:
                 if self.verbose > 1: print(f'CostGraph.find_nearest_factype: No path from {source_node} to {tnode}')
 
         # return the smallest of all lengths to get to typeofnode
-        if lengths:
+        if len(lengths) > 0:
+            if self.verbose > 1:
+                # For detailed debugging, save a file of all paths found and their lengths
+                pd.DataFrame([short_paths, lengths]).to_csv(f'{source_node}-findnearestfactype-{int(self.year)}-paths.csv', index=False)
             # dict of shortest paths to all targets
             nearest = min(lengths, key=lengths.get)
-            timeout_list = [1.0 for node in short_paths[nearest]]
+            timeout_list = [self.supply_chain.nodes[node]['timeout'] for node in short_paths[nearest]]
             dist_list = [
                 self.supply_chain.edges[short_paths[nearest][d : d + 2]]["dist"]
                 for d in range(len(short_paths[nearest]) - 1)
@@ -562,7 +566,7 @@ class CostGraph:
             values = _node_timeout_dict,
             name = 'timeout'
         )
-        
+
         if self.verbose > 0:
             print(f'CostGraph: Adding nodes and edges took {np.round((time() - _netime)/60, 2)} minutes',flush=True)
 

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -107,7 +107,9 @@ class CostGraph:
 
         # these data sets are processed line by line
         self.loc_file = locations_file
-        self.routes_file = routes_file
+
+        # This file now contains edge definitions, node metadata, and route distances
+        self.routes_file = pd.read_csv(routes_file)
 
         # also read in the locations as a dataframe for reference in
         # find_nearest
@@ -142,6 +144,18 @@ class CostGraph:
         self.run = run
         # create empty List to store the pathway cost output data
         self.pathway_crit_history = list()
+
+        # Create network structure and metadata df for network building
+        self.network_data = self.routes_file.merge(
+            self.step_costs[['step','step_cost_method']],
+            left_on = 'u_step',
+            right_on = 'step',
+            how = 'left'
+            ).merge(
+                self.transpo_edges,
+                on=['u_step','v_step'],
+                how='left'
+            )
 
         # create empty instance variable for supply chain DiGraph
         self.supply_chain = nx.DiGraph()
@@ -546,78 +560,6 @@ class CostGraph:
 
         return _nodes
 
-    def build_facility_graph(self, facility_df: pd.DataFrame):
-        """
-        Creates networkx DiGraph object containing nodes, intra-facility edges,
-        and all relevant attributes for a single facility.
-
-        Parameters
-        ----------
-        facility_df : pd.DataFrame
-            DataFrame with a single row that defines a supply chain facility.
-
-            Columns:
-                - facility_id : int
-                - facility_type : str
-                - lat : float
-                - long : float
-                - region_id_1 : str
-                - region_id_2 : str
-                - region_id_3 : str
-                - region_id_4 : str
-
-        Returns
-        -------
-        networkx.DiGraph
-            Directed graph representation of one supply chain facility.
-        """
-        if self.verbose > 1:
-            print(
-                "Building facility graph for ",
-                str(facility_df["facility_id"].values[0]),
-            )
-
-        # Create empty directed graph object
-        _facility = nx.DiGraph()
-
-        _id = str(facility_df["facility_id"].values[0])
-
-        # Generates list of (str, dict) tuples for node definition
-        _facility_nodes = self.get_nodes(facility_df)
-
-        # Populate the directed graph with node names and attribute
-        # dictionaries
-        _facility.add_nodes_from(_facility_nodes)
-
-        # Populate the directed graph with edges
-        # Edges within facilities don't have transportation costs or distances
-        # associated with them.
-        _edges = self.get_edges(facility_df)
-        _unique_edges = [tuple(map(lambda w: w + "_" + _id, x)) for x in _edges]
-
-        _methods = [
-            {
-                "cost_method": [
-                    getattr(
-                        self.cost_methods, _facility.nodes[edge[0]]["step_cost_method"]
-                    )
-                ],
-                "cost": 0.0,
-                "dist": 0.0,
-                "route_id": None,
-            }
-            for edge in _unique_edges
-        ]
-
-        _facility.add_edges_from(
-            self.list_of_tuples(
-                [node[0] for node in _unique_edges],
-                [node[1] for node in _unique_edges],
-                _methods,
-            )
-        )
-
-        return _facility
 
     def build_supplychain_graph(self):
         """
@@ -633,144 +575,28 @@ class CostGraph:
             print(f'CostGraph: Adding nodes and edges',flush=True)
 
         # add all facilities and intra-facility edges to supply chain
-        with open(self.loc_file, "r") as _loc_file:
-
-            _reader = pd.read_csv(_loc_file, chunksize=1)
-
-            for _line in _reader:
-
-                # Build the subgraph representation and add it to the list of
-                # facility subgraphs
-                _fac_graph = self.build_facility_graph(facility_df=_line)
-
-                # add onto the supply supply chain graph
-                self.supply_chain.add_nodes_from(_fac_graph.nodes(data=True))
-                self.supply_chain.add_edges_from(_fac_graph.edges(data=True))
+        # The format the networkx DiGraph needs is a list of three-tuples
+        # The first two elements per tuple define the u (source) and v 
+        # (destination) nodes
+        # The last element is a dictionary of edge attributes
+        all_edge_list = [ (
+            u_node,
+            v_node,
+            {'dist': dist, # the getattr method below pulls the actual function from costmethods.py
+            'cost_method': [getattr(self.cost_methods, node_cost), getattr(self.cost_methods, transpo_cost)],
+            'cost': -1.0,
+            'route_id': routeid}
+            )
+            for u_node, v_node, dist, node_cost, transpo_cost, routeid 
+            in zip(self.network_data.u_node_id, self.network_data.v_node_id,
+             self.network_data.vkmt, self.network_data.step_cost_method,
+             self.network_data.transpo_cost_method, self.network_data.route_id)
+        ]
+        
+        self.supply_chain.add_edges_from(all_edge_list)
 
         if self.verbose > 0:
             print(f'CostGraph: Adding nodes and edges took {np.round((time() - _netime)/60, 2)} minutes',flush=True)
-            print(f'CostGraph: Adding transport cost methods', flush = True)
-
-        _trtime = time()
-        # add all inter-facility edges, with costs but without distances
-        # this is a relatively short loop
-        for index, row in self.transpo_edges.iterrows():
-            if self.verbose > 2:
-                print(f'CostGraph: Adding transport cost methods to edges between {row["u_step"]} and {row["v_step"]}', flush = True)
-
-            _u = row["u_step"]
-            _v = row["v_step"]
-            _transpo_cost = row["transpo_cost_method"]
-
-            # get two lists of nodes to connect based on df row
-            _u_nodes = list(search_nodes(self.supply_chain, {"==": [("step",), _u]}))
-            _v_nodes = list(search_nodes(self.supply_chain, {"==": [("step",), _v]}))
-
-            # convert the two node lists to a list of tuples with all possible
-            # combinations of _u_nodes and _v_nodes
-            _edge_list = self.all_element_combos(_u_nodes, _v_nodes)
-
-            if not any(
-                [self.supply_chain.nodes[_v]["step"] in self.sc_end for _v in _v_nodes]
-            ):
-                _methods = [
-                    {
-                        "cost_method": [
-                            getattr(
-                                self.cost_methods,
-                                self.supply_chain.nodes[edge[0]]["step_cost_method"],
-                            ),
-                            getattr(self.cost_methods, _transpo_cost),
-                        ],
-                        "cost": 0.0,
-                        "dist": -1.0,
-                        "route_id": None,
-                    }
-                    for edge in _edge_list
-                ]
-            else:
-                _methods = [
-                    {
-                        "cost_method": [
-                            getattr(
-                                self.cost_methods,
-                                self.supply_chain.nodes[edge[0]]["step_cost_method"],
-                            ),
-                            getattr(self.cost_methods, _transpo_cost),
-                            getattr(
-                                self.cost_methods,
-                                self.supply_chain.nodes[edge[1]]["step_cost_method"],
-                            ),
-                        ],
-                        "cost": 0.0,
-                        "dist": -1.0,
-                        "route_id": None,
-                    }
-                    for edge in _edge_list
-                ]
-
-            # add these edges to the supply chain
-            self.supply_chain.add_edges_from(
-                self.list_of_tuples(
-                    [edge[0] for edge in _edge_list],
-                    [edge[1] for edge in _edge_list],
-                    _methods,
-                )
-            )
-
-        if self.verbose > 0:
-            print(f'CostGraph: Adding transport cost methods took {np.round((time() - _trtime)/60, 2)} minutes', flush = True)
-            print(f'CostGraph: Adding route distances', flush = True)
-        
-        # read in and process routes line by line
-        _route_file = pd.read_csv(self.routes_file).drop_duplicates(
-            subset = ["source_facility_id","source_facility_type",
-                        "destination_facility_id","destination_facility_type",
-                        "total_vkmt","route_id"],
-            inplace = False,
-            ignore_index = True
-        )
-        _ltime = time()
-        for _line in _route_file.iterrows():            
-            # find the source nodes for this route
-            _u = list(search_nodes(self.supply_chain,
-                                    {"and": [{"==": [("facility_id",), _line[1]['source_facility_id'],]},
-                                            {"in": [("connects",), ["out", "bid"]]}]
-                                    }
-                                )
-                    )
-            
-            if len(_u) == 0:
-                print(f'CostGraph: Node {_line[1]["source_facility_id"]} of type'
-                f' {_line[1]["source_facility_type"]} expected but not found',
-                flush = True)
-                continue
-
-
-            # Find the edge that connects the source and destination nodes for this route
-            _edge = [(u, v, dat) for u, v, dat in self.supply_chain.edges(_u, data = True) 
-                        if self.supply_chain.nodes[v]["facility_id"] == _line[1]['destination_facility_id']]
-            
-            if len(_edge) == 0:
-                print(f'CostGraph: Edge between {_line[1]["source_facility_id"]}_{_line[1]["source_facility_type"]}'
-                        f' and {_line[1]["destination_facility_type"]}_{_line[1]["destination_facility_id"]} expected but not found',
-                        flush = True)
-                continue
-
-            if self.verbose > 2:
-                print(f'CostGraph: Adding {_line[1]["total_vkmt"]} km between {_edge[0][0]} and {_edge[0][1]}', flush = True)
-            
-            self.supply_chain.edges[_edge[0][0], _edge[0][1]]['dist'] = _line[1]["total_vkmt"]
-            self.supply_chain.edges[_edge[0][0], _edge[0][1]]['route_id'] = _line[1]["route_id"]
-        
-        if self.verbose > 0:
-            print(f'CostGraph: Adding route distances took {np.round((time() - _ltime)/60, 2)} minutes', flush=True)
-
-        # After all of the route distances have been added, any edges that
-        # have a distance of -1 km are deleted from the network.
-        self.supply_chain.remove_edges_from(
-            [[u, v] for u, v, dat in self.supply_chain.edges.data() if dat['dist'] == -1.0]
-        )
 
         if self.verbose > 0:
             print(f'CostGraph: Calculating edge costs', flush=True)
@@ -804,6 +630,7 @@ class CostGraph:
 
         if self.verbose > 0:
             print(f'CostGraph: Instantiation took {np.round((time() - self.start_time)/60, 2)} minutes', flush = True)
+
 
     def choose_paths(self, source_node: str = None, crit: str = "cost"):
         """

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -299,7 +299,7 @@ class CostGraph:
         # Pull out a list of all nodes in the supply chain that are terminal
         # The linear supply chain terminates there, OR one loop of a circular pathway
         # terminates there
-        targets = [tnode for tnode in search_nodes(self.supply_chain, {"in": [("step",), self.sc_reenter]})]
+        targets = [tnode for tnode in self.supply_chain.nodes if any([scr in tnode for scr in self.sc_reenter])]
 
         # Loop thru terminal nodes
         # Use the loop rather than list comprehension b/c if a terminal node isn't reachable from the source
@@ -315,10 +315,9 @@ class CostGraph:
             except nx.NetworkXNoPath:
                 if self.verbose > 1: print(f'CostGraph.find_nearest: No path from {source_node} to {tnode}')
                 continue
-        
+        pdb.set_trace()
         # return the smallest of all lengths to get to typeofnode
         if len(lengths) > 0:
-            pdb.set_trace()
             # For detailed debugging, save a file of all paths found and their lengths
             pd.DataFrame([short_paths, lengths]).to_csv(f'{source_node}-{self.year}-paths.csv', index=False)
 
@@ -420,7 +419,7 @@ class CostGraph:
             print(f"Finding path from {source_node} to nearest {target_factype}")
 
         # We are only interested in a particular type(s) of node
-        targets = [tnode for tnode in search_nodes(self.supply_chain, {"in": [("step",), target_factype]})]
+        targets = [tnode for tnode in self.supply_chain.nodes if target_factype in tnode]
         
         short_paths = {}
         lengths = {}
@@ -489,41 +488,6 @@ class CostGraph:
             print(f'CostGraph.find_nearest_factype: No path from {source_node} to {target_factype} facility type')
             # not found, no path from source to typeofnode
             return None, None, None
-
-
-    def get_edges(self, facility_df: pd.DataFrame, u_edge="step", v_edge="next_step"):
-        """
-        Converts two columns of node names into a list of string tuples
-        for intra-facility edge definition with networkx
-
-        Parameters
-        ----------
-        facility_df
-            DataFrame listing processing steps (u_edge) and the next
-            processing step (v_edge) by facility type
-        u_edge
-            unique processing steps within a facility type
-        v_edge
-            steps to which the processing steps in u_edge connect
-
-        Returns
-        -------
-            list of string tuples that define edges within a facility type
-        """
-        if self.verbose > 1:
-            print("Getting edges for ", facility_df["facility_type"].values[0])
-
-        _type = facility_df["facility_type"].values[0]
-
-        _out = (
-            self.fac_edges[[u_edge, v_edge]]
-            .loc[self.fac_edges.facility_type == _type]
-            .dropna()
-            .to_records(index=False)
-            .tolist()
-        )
-
-        return _out
 
 
     def build_supplychain_graph(self):

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -706,7 +706,7 @@ class CostGraph:
              # the upstream nodes and _node. If not, remove those entries from _upstream_nodes
             for _u in _upstream_nodes:
                 try:
-                    _ = nx.astar_path(self.supply_chain, source = _node, target = _u)
+                    _ = nx.astar_path(self.supply_chain, source = _u, target = _node)
                 except nx.NetworkXNoPath:
                     _upstream_nodes.remove(_u)
         

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -325,7 +325,7 @@ class CostGraph:
 
             # dict of shortest paths to all targets
             nearest = min(lengths, key=lengths.get)
-            timeout_list = [1.0 for node in short_paths[nearest]]
+            timeout_list = [self.supply_chain.nodes[node]['timeout'] for node in short_paths[nearest]]
 
             dist_list = [
                 self.supply_chain.edges[short_paths[nearest][d : d + 2]]["dist"]
@@ -523,6 +523,8 @@ class CostGraph:
         _node_attr_dict = {}
         for node_id, facility_id in zip(self.network_data.u_node_id, self.network_data.u_facility_id):
             if node_id not in _node_attr_dict.keys(): _node_attr_dict[node_id] = facility_id
+        for node_id, facility_id in zip(self.network_data.v_node_id, self.network_data.v_facility_id):
+            if node_id not in _node_attr_dict.keys(): _node_attr_dict[node_id] = facility_id
 
         nx.set_node_attributes(
             self.supply_chain,
@@ -530,6 +532,37 @@ class CostGraph:
             name = 'facility_id'
         )
 
+        # Add timespan to nodes. Facilities with "in use" in the name get either 20 or 30 year lifespans
+        # @NOTE Eventually this should draw from facility information and component-level lifespans
+        # in the YAML files. This logic is a quick fix specific to the glass case study.
+        _node_timeout_dict = {}
+        for node_id in self.network_data.u_node_id:
+            if node_id not in _node_timeout_dict.keys(): 
+                if 'pv in use' in node_id:
+                    _timeout = 20.0
+                elif 'window in use' in node_id:
+                    _timeout = 30.0
+                else:
+                    _timeout = 1.0
+                
+                _node_timeout_dict[node_id] = _timeout
+        for node_id in self.network_data.v_node_id:
+            if node_id not in _node_timeout_dict.keys(): 
+                if 'pv in use' in node_id:
+                    _timeout = 20.0
+                elif 'window in use' in node_id:
+                    _timeout = 30.0
+                else:
+                    _timeout = 1.0
+                
+                _node_timeout_dict[node_id] = _timeout
+        
+        nx.set_node_attributes(
+            self.supply_chain,
+            values = _node_timeout_dict,
+            name = 'timeout'
+        )
+        
         if self.verbose > 0:
             print(f'CostGraph: Adding nodes and edges took {np.round((time() - _netime)/60, 2)} minutes',flush=True)
 

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -8,7 +8,7 @@ from networkx_query import search_nodes
 
 from celavi.costmethods import CostMethods
 
-import pdb
+
 class CostGraph:
     """
     Reads in supply chain data, creates a network of processing steps and facilities
@@ -355,7 +355,7 @@ class CostGraph:
             #    weight=crit,
             #    method="bellman-ford",
             #)
-            pdb.set_trace()
+
             for i in self.sc_end:
                 _dest = [key for key, value in lengths.items() if i in key]
                 _crit = [value for key, value in lengths.items() if i in key]

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -8,7 +8,7 @@ from networkx_query import search_nodes
 
 from celavi.costmethods import CostMethods
 
-import pdb
+
 class CostGraph:
     """
     Reads in supply chain data, creates a network of processing steps and facilities
@@ -146,8 +146,10 @@ class CostGraph:
         self.pathway_crit_history = list()
 
         # Create network structure and metadata df for network building
+        # @NOTE the drop_duplicates on step_costs will need to be removed
+        # for studies with facility-specific cost methods
         self.network_data = self.routes_file.merge(
-            self.step_costs[['step','step_cost_method']],
+            self.step_costs[['step','step_cost_method']].drop_duplicates(),
             left_on = 'u_step',
             right_on = 'step',
             how = 'left'
@@ -157,6 +159,14 @@ class CostGraph:
                 how='left'
             )
 
+        # Any edges without a defined transportation cost method are assigned
+        # the zero method
+        # This is intended solely for colocated nodes ie within the same
+        # facility
+        self.network_data.loc[
+            self.network_data.transpo_cost_method.isna(),
+            'transpo_cost_method'] = 'zero_method'
+        
         # create empty instance variable for supply chain DiGraph
         self.supply_chain = nx.DiGraph()
 
@@ -304,10 +314,20 @@ class CostGraph:
                 lengths[tnode] = nx.astar_path_length(self.supply_chain, source = source_node, target = tnode, weight = crit)
             except nx.NetworkXNoPath:
                 if self.verbose > 1: print(f'CostGraph.find_nearest: No path from {source_node} to {tnode}')
-                pass
-
+                continue
+        
         # return the smallest of all lengths to get to typeofnode
-        if lengths:
+        if len(lengths) > 0:
+            pdb.set_trace()
+            # For detailed debugging, save a file of all paths found and their lengths
+            pd.DataFrame([short_paths, lengths]).to_csv(f'{source_node}-{self.year}-paths.csv', index=False)
+
+            # Print a summary of the paths found
+            if self.verbose > 1:
+                print(f'CostGraph.find_nearest: {len(lengths)} paths from {source_node} to {targets} cost '
+                        f'${np.round(min(lengths),2)} - ${np.round(max(lengths),2)}',
+                        flush = True)
+
             # dict of shortest paths to all targets
             nearest = min(lengths, key=lengths.get)
             timeout = nx.get_node_attributes(self.supply_chain, "timeout")
@@ -362,7 +382,7 @@ class CostGraph:
             return nearest, lengths[nearest], _out
         else:
             # not found, no path from source to typeofnode
-            print(f'CostGraph.find_nearest: No path from {source_node} to any of {self.sc_reenter} nodes')
+            print(f'CostGraph.find_nearest: No paths from {source_node} to any of {self.sc_reenter} nodes')
             return None, None, None
 
 
@@ -528,16 +548,18 @@ class CostGraph:
             u_node,
             v_node,
             {'dist': dist, # the getattr method below pulls the actual function from costmethods.py
-            'cost_method': [getattr(self.cost_methods, node_cost), getattr(self.cost_methods, transpo_cost)],
+            'cost_method': [getattr(self.cost_methods, str(node_cost)), getattr(self.cost_methods, str(transpo_cost))],
             'cost': -1.0,
             'route_id': routeid}
             )
-            for u_node, v_node, dist, node_cost, transpo_cost, routeid 
-            in zip(self.network_data.u_node_id, self.network_data.v_node_id,
-             self.network_data.vkmt, self.network_data.step_cost_method,
-             self.network_data.transpo_cost_method, self.network_data.route_id)
+            for u_node, v_node, dist,
+                node_cost, transpo_cost,
+                routeid 
+            in zip(self.network_data.u_node_id, self.network_data.v_node_id, self.network_data.vkmt,
+            self.network_data.step_cost_method, self.network_data.transpo_cost_method,
+            self.network_data.route_id)
         ]
-        
+
         self.supply_chain.add_edges_from(all_edge_list)
 
         if self.verbose > 0:
@@ -569,7 +591,7 @@ class CostGraph:
 
         _cost_adjust = min([value for key, value in nx.get_edge_attributes(self.supply_chain, 'cost').items()])
         if _cost_adjust < 0.0:
-            print(f'CostGraph: Adjusting all costs for {self.year} upwards by \${np.round(_cost_adjust, 2)}', flush = True)
+            print(f'CostGraph: Adjusting all costs for {self.year} upwards by ${np.round(_cost_adjust, 2)}', flush = True)
             self.cost_adjustment_factor[self.year] = abs(_cost_adjust) if _cost_adjust < 0.0 else 0.0
             for edge in self.supply_chain.edges():
                 self.supply_chain.edges[edge]['cost'] = self.supply_chain.edges[edge]['cost'] + self.cost_adjustment_factor[self.year]
@@ -894,7 +916,7 @@ class CostGraph:
         
         _cost_adjust = min([value for key, value in nx.get_edge_attributes(self.supply_chain, 'cost').items()])
         if _cost_adjust < 0.0:
-            print(f'CostGraph.update_costs: Adjusting all costs for {self.year} upwards by \${np.round(_cost_adjust, 2)}',
+            print(f'CostGraph.update_costs: Adjusting all costs for {self.year} upwards by ${np.round(_cost_adjust, 2)}',
             flush = True)
             self.cost_adjustment_factor[self.year] = abs(_cost_adjust) if _cost_adjust < 0.0 else 0.0
 

--- a/celavi/costgraph.py
+++ b/celavi/costgraph.py
@@ -605,7 +605,7 @@ class CostGraph:
 
         _cost_adjust = min([value for key, value in nx.get_edge_attributes(self.supply_chain, 'cost').items()])
         if _cost_adjust < 0.0:
-            print(f'CostGraph: Adjusting all costs for {self.year} upwards by ${np.round(_cost_adjust, 2)}', flush = True)
+            print(f'CostGraph: Adjusting all costs for {self.year} upwards by ${np.round(abs(_cost_adjust), 2)}', flush = True)
             self.cost_adjustment_factor[self.year] = abs(_cost_adjust) if _cost_adjust < 0.0 else 0.0
             for edge in self.supply_chain.edges():
                 self.supply_chain.edges[edge]['cost'] = self.supply_chain.edges[edge]['cost'] + self.cost_adjustment_factor[self.year]
@@ -708,6 +708,8 @@ class CostGraph:
         _predec = [_node]
         while len(_upstream_nodes) == 0:
             _predec = [n for ns in [list(self.supply_chain.predecessors(p)) for p in _predec] for n in ns]
+            if len(_predec) == 0:
+                print(f'CostGraph.find_upstream_neighbor: {_node} has no predecessors', flush = True)
             _upstream_nodes = [n for n in _predec if any([n.find(begin + '_') != -1 for begin in self.sc_begin])]
             # Since we do this recursively, we also need to double check that a path exists between 
              # the upstream nodes and _node. If not, remove those entries from _upstream_nodes
@@ -930,7 +932,7 @@ class CostGraph:
         
         _cost_adjust = min([value for key, value in nx.get_edge_attributes(self.supply_chain, 'cost').items()])
         if _cost_adjust < 0.0:
-            print(f'CostGraph.update_costs: Adjusting all costs for {self.year} upwards by ${np.round(_cost_adjust, 2)}',
+            print(f'CostGraph.update_costs: Adjusting all costs for {self.year} upwards by ${np.round(abs(_cost_adjust), 2)}',
             flush = True)
             self.cost_adjustment_factor[self.year] = abs(_cost_adjust) if _cost_adjust < 0.0 else 0.0
 

--- a/celavi/diagnostic_viz.py
+++ b/celavi/diagnostic_viz.py
@@ -128,7 +128,10 @@ class DiagnosticViz:
 
         # The dropna() gets rid of all blank component counts, generally those
         # where the facility never processes a particular component
-        cumulative_histories_df = pd.concat(cumulative_histories).dropna()
+        cumulative_histories_df = pd.concat(cumulative_histories).fillna(0)
+
+        # Save a raw version of the histories file for debugging
+        cumulative_histories_df.to_csv('cumulative-histories-raw.csv',index=False)
 
         self.gathered_and_melted_cumulative_histories = (
             cumulative_histories_df.drop(["timestep", "year_floor", "facility_id"], axis=1)

--- a/celavi/routing.py
+++ b/celavi/routing.py
@@ -22,8 +22,9 @@ from joblib import Memory
 import tempfile
 import celavi.data_manager as Data
 import uuid
+import time
 
-
+import pdb
 class Router:
     """
     Calculate minimum-distance routes between supply chain facilities.
@@ -135,12 +136,11 @@ class Router:
 
     @staticmethod
     def get_all_routes(
-        locations_file,
-        route_pair_file,
-        distance_filtering,
+        network_edges,
         transportation_graph,
         node_locations,
         routes_output_file,
+        county_routes_file,
         routing_output_folder,
     ):
         """
@@ -152,14 +152,9 @@ class Router:
 
         Parameters
         ----------
-        locations_file : str
-            File containing processed supply chain facility locations.
-
-        route_pair_file : str
-            File defining the allowable facility pairs to connect with routes.
-
-        distance_filtering : str
-            File defining distance-based route filtering by facility pair.
+        network_edges : str
+            File of network structure defining source (u) and destination (v) locations
+            along with node and facility level metadata
 
         transportation_graph : str
             File of transportation network data.
@@ -168,7 +163,10 @@ class Router:
             File of node locations within transportation graph.
 
         routes_output_file : str
-            Path to file where complete routes dataset is saved.
+            Path to file where complete network + routes dataset is saved.
+        
+        county_routes_file : str
+            Path to file where routes with vkmt by county is saved.
 
         routing_output_folder : str
             Path to directory for intermediate routing outputs.
@@ -193,199 +191,82 @@ class Router:
             memory=Memory(location=_temp_dir),
         )
 
-        # import locations data
-        locations = pd.read_csv(locations_file)
-        route_pairs = Data.RoutePairs(fpath=route_pair_file, backfill=backfill)
-        # Get a list of destination facility types that must be in-state
-        # from route_pairs
-        _instate_dest = (
-            route_pairs[route_pairs["in_state_only"] == True]
-            .destination_facility_type.drop_duplicates()
-            .values
-        )
+        network = pd.read_csv(network_edges)
 
-        # identify states in locations data and loop through states (useful for debugging; loop could be removed)
-        # compute routes for all locations in each state and save results
-        state_list = locations.region_id_2.unique()
-        file_output_list = []
-        for state in state_list:
-            print(state, flush=True)
-            file_output = routing_output_folder + "route_list_output_{}.csv".format(
-                state
-            )
-            file_output_list.append(file_output)
+        _drop_edges = []
+        _network_dist = []
 
-            # select all source locations within this state
-            _source_loc = locations[locations.region_id_2 == state]
-            # select all destination locations in the complete data set
-            _dest_loc = locations
-            # rename columns before merging
-            _source_loc = _source_loc[
-                ["facility_id", "facility_type", "region_id_2", "lat", "long"]
-            ].add_prefix("source_")
-            _dest_loc = _dest_loc[
-                ["facility_id", "facility_type", "region_id_2", "lat", "long"]
-            ].add_prefix("destination_")
-            _source_loc.insert(0, "merge", "True")
-            _dest_loc.insert(0, "merge", "True")
+        vkmt_by_county_list = []
 
-            # merge source and destination pairs
-            source_dest_pairs = _source_loc.merge(_dest_loc, on="merge")
-
-            # Filter down to only the source/destination pairs allowed by route_pairs
-            source_dest_allowable_pairs = route_pairs[
-                ["source_facility_type", "destination_facility_type"]
-            ].apply(tuple, axis=1)
-            source_dest_complete_pairs = source_dest_pairs[
-                ["source_facility_type", "destination_facility_type"]
-            ].apply(tuple, axis=1)
-            source_dest_select_route_types = source_dest_complete_pairs.isin(
-                source_dest_allowable_pairs
-            )
-            selected_routes = source_dest_pairs[source_dest_select_route_types]
-            all_route_list = selected_routes.merge(
-                route_pairs, on=["source_facility_type", "destination_facility_type"]
-            )
-
-            # divide all_route_list into two sets of routes, one with connections
-            # within this state and one with connections out of state
-            instate_routes = all_route_list[
-                all_route_list.destination_region_id_2 == state
-            ]
-            outstate_routes = all_route_list[
-                all_route_list.destination_region_id_2 != state
-            ]
-
-            # Remove entries from the out-of-state route list where the
-            # connections are required to be in-state
-            _keep = outstate_routes.in_state_only == False
-            #route_list = instate_routes.append(outstate_routes[_keep])
-            route_list = pd.concat([instate_routes,outstate_routes[_keep]])
-
-            # if route_list is empty, generate empty data frame for export (e.g., create column for total_vkmt)
-            # otherwise, loop through all locations in route_list and compute routing distances
-            if route_list.empty:
-                print("list is empty")
-                route_list["vkmt"] = ""
-                route_list = route_list.drop(["merge"], axis=1)
-                route_list["total_vkmt"] = route_list.groupby(
-                    by=[
-                        "source_facility_id",
-                        "source_facility_type",
-                        "source_lat",
-                        "source_long",
-                        "destination_facility_id",
-                        "destination_facility_type",
-                        "destination_lat",
-                        "destination_long",
-                    ]
-                )["vkmt"].transform("sum")
-                route_list.to_csv(file_output)
-
-            else:
-
-                route_list.to_csv(routing_output_folder + "route_list.csv")
-
-                _routes = route_list[
-                    ["source_long", "source_lat", "destination_long", "destination_lat"]
-                ]
-
-                _routes.to_csv(routing_output_folder + "latlongs.csv")
-
-                # if routing engine is specified, use it to get the route (fips and
-                # vkmt) for each pair of input locations
-                if router is not None:
-
-                    # initialize holder for all routes
-                    _vkmt_by_county_all_routes = pd.DataFrame()
-
-                    # loop through all locations to compute routes
-                    print("finding routes", flush=True)
-                    for i in np.arange(_routes.shape[0]):
-
-                        # print every 20 routes
-                        if i % 20 == 0:
-                            print(i, flush=True)
-
-                        _vkmt_by_county = router.get_route(
-                            start=(
-                                _routes.source_long.iloc[i],
-                                _routes.source_lat.iloc[i],
-                            ),
-                            end=(
-                                _routes.destination_long.iloc[i],
-                                _routes.destination_lat.iloc[i],
-                            ),
-                        )
-
-                        # add identifier columns for later merging with route_list
-                        _vkmt_by_county["source_long"] = _routes.source_long.iloc[i]
-                        _vkmt_by_county["source_lat"] = _routes.source_lat.iloc[i]
-                        _vkmt_by_county[
-                            "destination_long"
-                        ] = _routes.destination_long.iloc[i]
-                        _vkmt_by_county[
-                            "destination_lat"
-                        ] = _routes.destination_lat.iloc[i]
-                        _vkmt_by_county["route_id"] = uuid.uuid4().hex
-
-                        # either create the data frame to store all routes,
-                        # or append the current route
-                        if _vkmt_by_county_all_routes.empty:
-                            _vkmt_by_county_all_routes = _vkmt_by_county
-
-                        else:
-                            _vkmt_by_county_all_routes = pd.concat([_vkmt_by_county_all_routes,_vkmt_by_county])
-                            _vkmt_by_county_all_routes = _vkmt_by_county_all_routes.sort_values(by = list(_vkmt_by_county_all_routes.columns),axis = 0)
-                            
-
-                    # after the loop through all routes is complete, merge the data
-                    # frame containing all routes with route_list
-                    route_list = route_list.merge(
-                        _vkmt_by_county_all_routes,
-                        how="left",
-                        on=[
-                            "source_long",
-                            "source_lat",
-                            "destination_long",
-                            "destination_lat",
-                        ],
+        if router is None:
+            print('No router found', flush = True)
+            
+        else:
+            print(f'Router.get_all_routes: Finding {len(network)} routes', flush = True)
+            _rtime = time.time()
+            for idx, edge in network.iterrows():
+                # Do not find routes between co-located nodes
+                if edge.u_facility_id == edge.v_facility_id:
+                    _network_dist = _network_dist + [{'index': idx, 'vkmt': 0.0, 'route_id': 'colocated'}]
+                # Do not find routes between co-located facilities
+                elif edge.u_lat == edge.v_lat and edge.u_long == edge.v_long:
+                    _network_dist = _network_dist + [{'index': idx, 'vkmt': 0.0, 'route_id': 'colocated'}]
+                else:
+                    _vkmt_by_county = router.get_route(
+                        start=(
+                            edge.u_long,
+                            edge.u_lat,
+                        ),
+                        end=(
+                            edge.v_long,
+                            edge.v_lat,
+                        ),
                     )
+                    # If the route distance is greater than a max distance, do not save
+                    # the route information. Instead, record the index to drop it from
+                    # the network routes file
+                    if _vkmt_by_county.vkmt.sum() > edge.vkmt_max:
+                        _drop_edges = _drop_edges + [idx]
+                    # If the route returned has a total distance of under 1 kilometer, assume
+                    # those facilities are colocated
+                    # This accounts for facilities that are essentially colocated but don't
+                    # have numerically identical lat/long values
+                    elif _vkmt_by_county.vkmt.sum() < 1.0:
+                        _network_dist = _network_dist + [{'index': idx, 'vkmt': 0.0, 'route_id': 'colocated'}]
+                    else:
+                        # Assign a route id and node information to the county-level distance data
+                        _vkmt_by_county['route_id'] = uuid.uuid4().hex
+                        _vkmt_by_county['u_node_id'] = edge.u_node_id
+                        _vkmt_by_county['v_node_id'] = edge.v_node_id
+                        # Save the total distance into the network dataframe
+                        _network_dist = _network_dist + [{'index': idx, 'vkmt': _vkmt_by_county.vkmt.sum(), 'route_id': _vkmt_by_county.route_id.unique()[0]}]
+                        # Attach the county-level data to a list for later saving
+                        vkmt_by_county_list = vkmt_by_county_list + [_vkmt_by_county]
+                
+                # Print a status message every 100 routes
+                if idx % 100 == 0: print(f'Router.get_all_routes: {idx} routes found after {np.round((time.time() - _rtime)/60, 1)} minutes', flush = True)
+            
+            network_routes = network.merge(
+                pd.DataFrame(_network_dist),
+                left_index = True,
+                right_on = 'index',
+                how = 'left'
+            )
+            # Remove edges from the network if any have distances greater than the max allowed
+            if len(_drop_edges) > 0:
+                pdb.set_trace()
+                network_routes.drop(index = [int(e) for e in _drop_edges], inplace = True)
+            
+            # Save the network routes file for use in Cost Graph
+            network_routes.to_csv(routes_output_file, index=False)
 
-                route_list = route_list.drop(["merge"], axis=1)
-                # compute total_vkmt
-                route_list["total_vkmt"] = route_list.groupby(
-                    by=[
-                        "source_facility_id",
-                        "source_facility_type",
-                        "source_lat",
-                        "source_long",
-                        "destination_facility_id",
-                        "destination_facility_type",
-                        "destination_lat",
-                        "destination_long",
-                    ]
-                )["vkmt"].transform("sum")
+            # Calculate total distance over fclass and save the county level di
+            vkmt_by_county_all = pd.concat(vkmt_by_county_list).groupby(
+                ['u_node_id','v_node_id','route_id','region_transportation']
+                ).sum(
+                    'vkmt'
+                    ).reset_index()
+            
+            vkmt_by_county_all.drop(columns='fclass', inplace = True)
 
-                # if the routes should be filtered based on distance,
-                if distance_filtering:
-                    # remove rows where total_vkmt > max distance
-                    route_list = route_list[
-                        route_list.total_vkmt <= route_list.vkmt_max
-                    ]
-
-                # remove columns used in distance filtering
-                route_list.drop(
-                    labels=["in_state_only", "vkmt_max"], axis=1, inplace=True
-                )
-
-                route_list.to_csv(file_output)
-
-        # append all data from independent state loops into one master routing data frame
-        data_complete = pd.DataFrame()
-        for file in file_output_list:
-            data = pd.read_csv(file)
-            data_complete = pd.concat([data_complete,data])
-
-        data_complete.to_csv(routes_output_file, index=False)
-
+            vkmt_by_county_all.to_csv(county_routes_file, index=False)

--- a/celavi/routing.py
+++ b/celavi/routing.py
@@ -24,7 +24,7 @@ import celavi.data_manager as Data
 import uuid
 import time
 
-import pdb
+
 class Router:
     """
     Calculate minimum-distance routes between supply chain facilities.
@@ -226,6 +226,7 @@ class Router:
                     # the route information. Instead, record the index to drop it from
                     # the network routes file
                     if _vkmt_by_county.vkmt.sum() > edge.vkmt_max:
+                        _network_dist = _network_dist + [{'index': idx, 'vkmt': _vkmt_by_county.vkmt.sum(), 'route_id': 'vkmt_max'}]
                         _drop_edges = _drop_edges + [idx]
                     # If the route returned has a total distance of under 1 kilometer, assume
                     # those facilities are colocated
@@ -254,18 +255,18 @@ class Router:
             )
             # Remove edges from the network if any have distances greater than the max allowed
             if len(_drop_edges) > 0:
-                pdb.set_trace()
-                network_routes.drop(index = [int(e) for e in _drop_edges], inplace = True)
+                network_routes.to_csv('network-routes-all.csv', index=False)
+                network_routes.drop(_drop_edges, inplace = True)
             
             # Save the network routes file for use in Cost Graph
             network_routes.to_csv(routes_output_file, index=False)
 
             # Calculate total distance over fclass and save the county level di
-            vkmt_by_county_all = pd.concat(vkmt_by_county_list).groupby(
-                ['u_node_id','v_node_id','route_id','region_transportation']
-                ).sum(
-                    'vkmt'
-                    ).reset_index()
+            vkmt_by_county_all = pd.concat(
+                vkmt_by_county_list
+                ).groupby(
+                    ['u_node_id','v_node_id','route_id','region_transportation']
+                    ).sum('vkmt').reset_index()
             
             vkmt_by_county_all.drop(columns='fclass', inplace = True)
 

--- a/celavi/routing.py
+++ b/celavi/routing.py
@@ -193,7 +193,14 @@ class Router:
 
         network = pd.read_csv(network_edges)
 
-        _drop_edges = []
+        # Get a table of which processing steps require downstream
+        # landfill facilities, for use in postprocessing routes
+        _landfill_edges = network.loc[
+            [vkmtmax > 0 and instate 
+            for vkmtmax, instate in zip(network.vkmt_max, network.in_state)],
+            ['u_step','v_step']
+            ].drop_duplicates().reset_index()
+        
         _network_dist = []
 
         vkmt_by_county_list = []
@@ -204,7 +211,7 @@ class Router:
         else:
             print(f'Router.get_all_routes: Finding {len(network)} routes', flush = True)
             _rtime = time.time()
-            for idx, edge in network.iterrows():
+            for idx, edge in network.iterrows():                
                 # Do not find routes between co-located nodes
                 if edge.u_facility_id == edge.v_facility_id:
                     _network_dist = _network_dist + [{'index': idx, 'vkmt': 0.0, 'route_id': 'colocated'}]
@@ -227,7 +234,6 @@ class Router:
                     # the network routes file
                     if _vkmt_by_county.vkmt.sum() > edge.vkmt_max:
                         _network_dist = _network_dist + [{'index': idx, 'vkmt': _vkmt_by_county.vkmt.sum(), 'route_id': 'vkmt_max'}]
-                        _drop_edges = _drop_edges + [idx]
                     # If the route returned has a total distance of under 1 kilometer, assume
                     # those facilities are colocated
                     # This accounts for facilities that are essentially colocated but don't
@@ -247,17 +253,53 @@ class Router:
                 # Print a status message every 100 routes
                 if idx % 100 == 0: print(f'Router.get_all_routes: {idx} routes found after {np.round((time.time() - _rtime)/60, 1)} minutes', flush = True)
             
-            network_routes = network.merge(
+            network_all_routes = network.merge(
                 pd.DataFrame(_network_dist),
                 left_index = True,
                 right_on = 'index',
                 how = 'left'
             )
+
+            # Save the raw routes file including edges that violate the vkmt_max
+            network_all_routes.to_csv('network-routes-all.csv', index=False)
+
             # Remove edges from the network if any have distances greater than the max allowed
-            if len(_drop_edges) > 0:
-                network_routes.to_csv('network-routes-all.csv', index=False)
-                network_routes.drop(_drop_edges, inplace = True)
+            if any(network_all_routes.route_id == 'vkmt_max'):
+                network_routes = network_all_routes.drop(network_all_routes.loc[network_all_routes.route_id == 'vkmt_max',:].index)
+
+                # Check through the dataset of nodes that require connections to a landfill
+                # If the vkmt_max restriction has removed all edges from these nodes to landfills,
+                # locate the nearest landfill and re-add that edge to the network regardless 
+                # of the vkmt_max
+                _add_edges = pd.DataFrame()
+                for _, edge in _landfill_edges.iterrows():
+                    _nodes_need_landfills = list(
+                        set(
+                            network_all_routes.loc[network_all_routes.u_step == edge['u_step'],'u_node_id'].drop_duplicates()
+                        ).difference(
+                            network_routes.loc[[(u == edge['u_step']) and (v == edge['v_step']) for u, v in zip(network_routes.u_step, network_routes.v_step)],'u_node_id'].drop_duplicates()
+                            )
+                        )
+                    if len(_nodes_need_landfills) > 0:
+                        _closest_landfills = network_all_routes.loc[
+                            (network_all_routes.u_node_id.isin(_nodes_need_landfills)) & (network_all_routes.v_step == edge.v_step),:
+                            ].groupby('u_node_id').agg({'vkmt':'min'}).reset_index()
+                        if len(_closest_landfills) == 0:
+                            # If the nodes have no available downstream facilities, print a warning
+                            # The location data may need to be revised in this case
+                            print(f'Router.get_all_routes: Nodes {_nodes_need_landfills} have no available {edge.v_step} nodes')
+                        else:
+                            _add_edges = pd.concat(
+                                [_add_edges,
+                                network_all_routes.loc[
+                                    (network_all_routes.u_node_id.isin(_nodes_need_landfills)) & (network_all_routes.v_step == edge.v_step) & (network_all_routes.vkmt.isin(_closest_landfills.vkmt)), :]
+                                    ]
+                                )
+                        
             
+            # Add in the landfill connections
+            network_routes = pd.concat([network_routes, _add_edges]).reset_index()
+
             # Save the network routes file for use in Cost Graph
             network_routes.to_csv(routes_output_file, index=False)
 

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -28,7 +28,7 @@ from celavi.diagnostic_viz import DiagnosticViz
 
 
 
-
+import pdb
 class Scenario:
     """
     Set up, validate, and execute a CELAVI scenario.
@@ -216,21 +216,44 @@ class Scenario:
             if not self.scen["flags"].get("run_routes", True):
                 print(f"Filtering routes: {states_to_filter}", flush=True)
                 filter_routes(self.files["locs"], _routefile)
+        
+        # Generate file of network edges with node/facility IDs and locations
+        network_structure = pd.read_csv(self.files['network_structure'])
+        locations = pd.read_csv(self.files['locs'])
+        network_full = network_structure.copy().merge(
+            locations.add_prefix('u_'),
+            on = ['u_facility_type'],
+            how = 'left'
+            ).merge(
+                locations.add_prefix('v_'),
+                on = ['v_facility_type'],
+                how = 'left'
+                )
+
+        network_full.loc[:,'u_node_id'] = [f'{step}_{fid}' for step, fid in zip(network_full.u_step, network_full.u_facility_id)]
+        network_full.loc[:,'v_node_id'] = [f'{step}_{fid}' for step, fid in zip(network_full.v_step, network_full.v_facility_id)]
+
+        network_full.drop(columns = ['u_step','v_step'], inplace = True)
+
+        _drop_edges = network_full.loc[[(instate == True) and (u_state != v_state) for instate, u_state, v_state in zip(network_full.in_state, network_full.u_region_id_2, network_full.v_region_id_2)],:].index
+
+        network_full.drop(index = _drop_edges, inplace = True)
+
+        network_full.to_csv(self.files['network_edges'], index = False)
 
         if self.scen["flags"].get("run_routes", True):
             Router.get_all_routes(
-                locations_file=self.files["locs"],
-                route_pair_file=self.files["route_pairs"],
-                distance_filtering=self.scen["flags"].get("distance_filtering", False),
+                network_edges=self.files['network_edges'],
                 transportation_graph=self.files["transportation_graph"],
                 node_locations=self.files["node_locs"],
                 routes_output_file=_routefile,
                 routing_output_folder=os.path.join(
                     self.args.data, self.case["directories"].get("generated")
                 ),
-            )
-
-        print(f"Run routes completed in {self.simtime(self.start)} s", flush=True)
+                county_routes_file = self.files['county_routes']
+                ),
+        pdb.set_trace()
+        print(f"Run routes completed at {self.simtime(self.start)} s", flush=True)
 
     def setup(self):
         """Create instances of CostGraph, DES (Context and Components) and PyLCIA."""

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -28,7 +28,7 @@ from celavi.diagnostic_viz import DiagnosticViz
 
 
 
-
+import pdb
 class Scenario:
     """
     Set up, validate, and execute a CELAVI scenario.
@@ -234,6 +234,17 @@ class Scenario:
                 on = ['v_facility_type'],
                 how = 'left'
                 )
+        
+        # Identify and drop rows where intra-facility connections have been made between
+        # facilities
+        network_full.drop(
+            network_full.loc[
+                [(utype == vtype) and (u_facility != v_facility) 
+                for utype, vtype, u_facility, v_facility 
+                in zip(network_full.u_facility_type, network_full.v_facility_type, 
+                        network_full.u_facility_id, network_full.v_facility_id)],:].index,
+                 inplace = True
+        )
 
         # Create unique node_ids for every node based on the processing step and the
         # facility id

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -100,8 +100,6 @@ class Scenario:
         # Instantiate model
         self.setup()
 
-        print(f"Simulations starting at {self.simtime(self.start)} s", flush=True)
-
         # Execute all model runs
         # Subtract one from the number of runs in the config file because
         # arange includes zero in the list
@@ -442,7 +440,6 @@ class Scenario:
             manuf_facility = self.netw.find_upstream_neighbor(
                 row["facility_id"]
             )
-
             # Optional print statement for component monitoring
             if self.case["model_run"].get("warning_verbose") > 1:
                 print(f'{row.facility_id} , {row.year}: {manuf_facility}')
@@ -474,6 +471,7 @@ class Scenario:
                         )
                     else:
                         pass
+                if len(components) % 100 == 0: print(f'{len(components)} components instantiated')
 
         components = pd.DataFrame(components)
 

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -28,7 +28,7 @@ from celavi.diagnostic_viz import DiagnosticViz
 
 
 
-import pdb
+
 class Scenario:
     """
     Set up, validate, and execute a CELAVI scenario.
@@ -264,8 +264,7 @@ class Scenario:
                     self.args.data, self.case["directories"].get("generated")
                 ),
                 county_routes_file = self.files['county_routes']
-                ),
-        pdb.set_trace()
+                )
         print(f"Run routes completed at {self.simtime(self.start)} s", flush=True)
 
     def setup(self):

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -28,7 +28,7 @@ from celavi.diagnostic_viz import DiagnosticViz
 
 
 
-import pdb
+
 class Scenario:
     """
     Set up, validate, and execute a CELAVI scenario.

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -299,7 +299,6 @@ class Scenario:
                 step_costs_file=self.files["step_costs"]
                 if self.scen["flags"].get("generate_step_costs")
                 else self.files["step_costs_custom"],
-                fac_edges_file=self.files["fac_edges"],
                 transpo_edges_file=self.files["transpo_edges"],
                 locations_file=self.files["locs"],
                 routes_file=self.files["routes_computed"]

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -218,7 +218,14 @@ class Scenario:
                 filter_routes(self.files["locs"], _routefile)
         
         # Generate file of network edges with node/facility IDs and locations
+
+        # The network_structure file defines connections between nodes and assigns
+        # facility types, vkmt_max, instateonly boolean and a loss boolean to
+        # every connection
         network_structure = pd.read_csv(self.files['network_structure'])
+
+        # By merging the network structure with the facility locations, the
+        # entire set of edges within the network is defined
         locations = pd.read_csv(self.files['locs'])
         network_full = network_structure.copy().merge(
             locations.add_prefix('u_'),
@@ -230,15 +237,21 @@ class Scenario:
                 how = 'left'
                 )
 
+        # Create unique node_ids for every node based on the processing step and the
+        # facility id
         network_full.loc[:,'u_node_id'] = [f'{step}_{fid}' for step, fid in zip(network_full.u_step, network_full.u_facility_id)]
         network_full.loc[:,'v_node_id'] = [f'{step}_{fid}' for step, fid in zip(network_full.v_step, network_full.v_facility_id)]
 
-        network_full.drop(columns = ['u_step','v_step'], inplace = True)
-
-        _drop_edges = network_full.loc[[(instate == True) and (u_state != v_state) for instate, u_state, v_state in zip(network_full.in_state, network_full.u_region_id_2, network_full.v_region_id_2)],:].index
-
+        # Generate list of edges to remove from the network based on the in-state boolean
+        # and whether the u and v nodes are within the same state
+        _drop_edges = network_full.loc[
+            [(instate == True) and (u_state != v_state) 
+            for instate, u_state, v_state 
+            in zip(network_full.in_state, network_full.u_region_id_2, network_full.v_region_id_2)],:].index
         network_full.drop(index = _drop_edges, inplace = True)
 
+        # Save the edges to file
+        # Route distances and IDs are added by the Router
         network_full.to_csv(self.files['network_edges'], index = False)
 
         if self.scen["flags"].get("run_routes", True):

--- a/celavi_input_checks.py
+++ b/celavi_input_checks.py
@@ -17,7 +17,7 @@ class FileChecks:
     created with descriptive messages before they are raised.
     """
 
-    def __init__(self, locations, step_costs, fac_edges, routes, transpo_edges):
+    def __init__(self, locations, step_costs, routes, transpo_edges):
         """
         Initializes the file integrity checks by copying the filenames
         to instance variables.
@@ -30,9 +30,6 @@ class FileChecks:
         step_costs: str
             Path to the step_costs file
 
-        fac_edges: str
-            Path to the facility edges file
-
         routes: str
             Path to the routes file
 
@@ -41,13 +38,11 @@ class FileChecks:
         """
         self.locations_filename = locations
         self.step_costs_filename = step_costs
-        self.fac_edges_filename = fac_edges
         self.routes_filename = routes
         self.transpo_edges_filename = transpo_edges
 
         self.locations: pd.DataFrame = None
         self.step_costs: pd.DataFrame = None
-        self.fac_edges: pd.DataFrame = None
         self.routes: pd.DataFrame = None
         self.transpo: pd.DataFrame = None
 
@@ -71,9 +66,6 @@ class FileChecks:
 
         if not os.path.isfile(self.step_costs_filename):
             raise Exception(f'Step costs file {self.step_costs_filename} does not exist.')
-
-        if not os.path.isfile(self.fac_edges_filename):
-            raise Exception(f'Facility edges file {self.fac_edges_filename} does not exist.')
 
         if not os.path.isfile(self.routes_filename):
             raise Exception(f'Routes file {self.routes_filename} does not exist.')
@@ -103,11 +95,6 @@ class FileChecks:
             self.step_costs = pd.read_csv(self.step_costs_filename)
         except (pd.EmptyDataError, FileNotFoundError):
             raise Exception(f'{self.step_costs_filename} failed to read as a .csv')
-
-        try:
-            self.fac_edges = pd.read_csv(self.fac_edges_filename)
-        except (pd.EmptyDataError, FileNotFoundError):
-            raise Exception(f'{self.fac_edges_filename} failed to read as a .csv')
 
         try:
             self.routes = pd.read_csv(self.routes_filename)
@@ -152,9 +139,6 @@ class FileChecks:
         if self.locations['facility_type'].isnull().values.any():
             raise Exception('facility_type in locations has an empty value.')
 
-        if self.fac_edges['facility_type'].isnull().values.any():
-            raise Exception('facility_type in fac_edges has an empty value.')
-
         if self.routes['source_facility_type'].isnull().values.any():
             raise Exception('source_facility_type in routes has an empty value.')
 
@@ -198,9 +182,6 @@ class FileChecks:
 
         if self.transpo_edges['transpo_cost_method'].isnull().values.any():
             raise Exception('transpo_cost_method in transpo_edges has a null value')
-
-        if self.fac_edges['step'].isnull().values.any():
-            raise Exception('step in fac_edges has a null value')
 
     def check_joins_on_facility_id(self):
         """
@@ -283,21 +264,6 @@ class FileChecks:
             facility_types.
         """
 
-        # An outer join is used here to include all rows on both sides of the join
-        # Check for null values on the left/right side of the join, and use ids on the
-        # opposite right/left side of the join to generate error messages about
-        # unmatched rows on the other side of the join.
-
-        join1 = self.locations.merge(self.fac_edges, on='facility_type', how='outer')
-        if join1['facility_id'].isna().values.any():
-            facility_type = join1[join1['facility_id'].isna().values]['facility_type'].values
-            raise Exception(
-                f'There is a fac_edges.facility_type {facility_type} that does not exist in locations.facility_type')
-        if join1['step'].isna().values.any():
-            facility_type = join1[join1['step'].isna().values]['facility_type'].values
-            raise Exception(
-                f'There is a locations.facility_type {facility_type} that does not exist in fac_edges.facility_type')
-
         # An outer join is used here to include all rows on both sides of the join.
         # Use the left side of the join to check for facility types referenced by routes that
         # do not exist in locations.
@@ -315,7 +281,7 @@ class FileChecks:
         # Use the left side of the join to check for facility types referenced by routes that
         # do not exist in locations.
         # Use the right side of the join to create error messages about route destination
-        # facility types that do not exist fac_edges.
+        # facility types that do not exist in locations.facility_type.
 
         join4 = self.locations.merge(self.routes, left_on='facility_type', right_on='destination_facility_type',
                                      how='outer')
@@ -324,19 +290,6 @@ class FileChecks:
                 'destination_facility_type'].values
             raise Exception(
                 f'There is a routes.destination_facility_type {destination_facility_type} that does not exist in locations.facility_type.'
-            )
-
-        # An outer join is used here to include all rows on both sides of the join.
-        # Use the left side of the join to check for facility types referenced by routes that
-        # do not exist in face_edges.
-        # Use the right side of the join to create error messages about route source
-        # facility types that do not exist fac_edges.
-
-        join3 = self.fac_edges.merge(self.routes, left_on='facility_type', right_on='source_facility_type', how='outer')
-        if join3['facility_type'].isna().values.any():
-            source_facility_type = join3[join3['facility_type'].isna().values]['source_facility_type'].values
-            raise Exception(
-                f'There is a routes.source_facility_type {source_facility_type} that does not exist in fac_edges.facility_type'
             )
 
     def check_step_joins(self):
@@ -348,20 +301,6 @@ class FileChecks:
         Exception
             Raises an exception if there are any problems with the step ids.
         """
-
-        # An outer join is used here to include all rows on both sides of the join
-        # Check for null values on the left/right side of the join, and use ids on the
-        # opposite right/left side of the join to generate error messages about
-        # unmatched rows on the other side of the join.
-
-        join1 = self.step_costs.merge(self.fac_edges, on='step', how='outer')
-        if join1['facility_type'].isna().values.any():
-            step = join1[join1['facility_type'].isna().values]['step'].values
-            raise Exception(f'There is a step_costs.step of {step} that does not exist in fac_edges.step.')
-        if join1['step_cost_method'].isna().values.any():
-            step = join1[join1['step_cost_method'].isna().values]['step'].values
-            raise Exception(f'There is a fac_edges.step {step} that does not exist in step_cost_method.step.')
-
         # An outer join is used here to include all rows on both sides of the join.
         # Use the left side of the join to check for u_steps referenced by transpo_edges
         # that do not exist step_costs.
@@ -384,36 +323,19 @@ class FileChecks:
             v_step = join3[join3['step'].isna().values]['v_step'].values
             raise Exception(f'There is a transpo_edges.v_step {v_step} that does not exist in step_costs.step.')
 
-        # An outer join is used here to include all rows on both sides of the join.
-        # Use the left side of the join to check for next_steps referenced by fac_edges
-        # that do not exist step_costs.
-        # Use the right side of the join to create error messages about next_steps
-        # that do not exist step_costs.
-        # Note that since next_step is optional, do not generate an error messages
-        # for next_steps that are null.
-
-        join4 = self.step_costs.merge(self.fac_edges, left_on='step', right_on='next_step', how='outer')
-        if join4['step_x'].isna().values.any():
-            next_step = join4[join4['step_x'].isna().values]['next_step'].values
-            next_step_not_all_na = join4[join4['step_x'].isna().values]['next_step'].isna().values.all()
-            if not next_step_not_all_na:   # next_step is optional, so nan should not throw an error
-                raise Exception(f'There is a fac_edges.next_step {next_step} that does not exist in step_costs.step.')
-
 
 def main():
     # Filenames
-    # locations, step_costs, fac_edges, routes, transpo_edges
+    # locations, step_costs, routes, transpo_edges
     parser = argparse.ArgumentParser(description='Check CELAVI input data')
     parser.add_argument('--locations', help='Path to locations file')
     parser.add_argument('--step_costs', help='Path to step_costs file')
-    parser.add_argument('--fac_edges', help='Facility edges file')
     parser.add_argument('--routes', help='Routes file')
     parser.add_argument('--transpo_edges', help='Transportation edges file')
     args = parser.parse_args()
     file_checks = FileChecks(
         locations=args.locations,
         step_costs=args.step_costs,
-        fac_edges=args.fac_edges,
         routes=args.routes,
         transpo_edges=args.transpo_edges
     )

--- a/docs/doc_config.rst
+++ b/docs/doc_config.rst
@@ -53,7 +53,6 @@ Case Study Config Template
 			lookup_steps:
 			lookup_transpo_cost_methods:
 			lookup_step_cost_methods:
-			fac_edges:
 			transpo_edges:
 			route_pairs:
 			component_material_mass:
@@ -328,7 +327,6 @@ Case Study Config Example
 			lookup_steps: step.csv
 			lookup_transpo_cost_methods: transpo_cost_method.csv
 			lookup_step_cost_methods: step_cost_method.csv
-			fac_edges: fac_edges.csv
 			transpo_edges: transpo_edges.csv
 			route_pairs: route_pairs.csv
 			component_material_mass: avgmass.csv


### PR DESCRIPTION
We've been having consistent issues with defining and verifying the network structure, and having to manage half a dozen different input files with this information isn't helping. The `CostGraph` instantiation process was taking 10-15 minutes which is excessive for the network size we're working with. `Router` ditto, was finding far more routes than were actually needed in the network.

This PR and the associated [data PR](https://github.nrel.gov/rhanes/celavi-data/pull/99) (national scale only for the moment) accomplish:

- Replaces most of the network structure input files with a single, relatively human readable csv file called network-structure.csv - see attached.
- Works from the network-structure file and the locations_computed data structure to generate a dataframe, "network_edges" (attached), that defines all the edges and metadata required to instantiate `CostGraph`, except for the distances, route_ids (obtained via `Router.get_all_routes`), and numerical costs (calculated during instantiation). network_edges is generated in scenario.py.
- Refactors `Router.get_all_routes` to run off the network_edges data structure instead of the locations_computed file. This cuts down the number of calls to the router and provides a handy way to identify edges with no distances/routes (ie colocated nodes) and edges that should not be included in `CostGraph` (ie in-state connections).
    - I sped up all the non-route-finding operations in `Router.get_all_routes`, and current speed is right around 100 routes per minute. For the glass case study that works out to a little under 90 minutes, although I'm seeing substantial variation in that time on my machine. I implemented some timing during development and confirmed the holdup is indeed the actual route finding, and so this is about as good as it gets. I still recommend using pre-computed routes when debugging locally.
- The routes_computed file has the same name but looks substantially different: it's network_edges with additional columns for vkmt and route_id. As a bonus, this file is now ~5 MB and can live on Git instead of Kestrel.
- Refactors `CostGraph.build_supplychain_graph` to be a self-contained method - no more sub-methods that define facilities/nodes/edges - that first processes the network_edges file to generate a list of edges in a networkx-friendly format, then creates the network from the list of edges in a single step, followed by the addition of the facility_id node attribute (required for pathfinding logic). After refactorization, CostGraph instantiation is essentially instant even with the full national data set (glass study).
- Incidentally, because of the way `Router.get_all_routes` now executes, it's simpler to save the routes-and-distances-by-county data in case we ever want to use that to disaggregate transpo emissions by county traversed. This file is vkmt-county-all.csv (available in the data repo).
- In testing the above new features, several bugs and logic errors were identified and fixed, **including one bug that was likely preventing landfilling from being chosen as an EOL pathway**. See commit [a461d2e](https://github.com/NREL/celavi/pull/267/commits/a461d2e2254ad8471e7853d25a50684a2f5718cb).
- Other bugs identified and fixes implemented during testing: 
    - Some nodes lost all downstream connections to landfills due to the vkmt_max logic; Router now checks for this and adds in the closest landfill to only these nodes regardless of vkmt_max.
    - Washington, DC power plants and buildings had no downstream landfills because there are no DC landfills in the LMOP dataset; compute_locations now filters out DC facilities in addition to Alaska, Hawaii, etc. We could alternatively add in fake landfills in DC if we want to keep the DC power plants and buildings.

Testing on the national data has completed. Output and diagnostic results are below.

The latest CostGraph file is also attached for review.

[network-structure.csv](https://github.com/user-attachments/files/19411841/network-structure.csv)

[network_edges.csv](https://github.com/user-attachments/files/19437185/network_edges.csv)

[netw.csv](https://github.com/user-attachments/files/19437188/netw.csv)

Output from completed national run w/out computing routes:

```
(celavisandbox3) C:\Users\rhanes\GitHub\celavi>python -m celavi --data C:\Users\rhanes\GitHub\celavi-data --casestudy casestudy.yaml --scenario scenario.yaml
Preprocessing starting at 0 s
validating PVTechUnitLocations
validated PVTechUnitLocations
no missing data values in celavi.data_manager.PVTechUnitLocations.eia_id
no missing data values in celavi.data_manager.PVTechUnitLocations.p_year
validating CommWindowTechUnitLocations
validated CommWindowTechUnitLocations
no missing data values in celavi.data_manager.CommWindowTechUnitLocations.year
validating LandfillLocations
validated LandfillLocations
279 of 2637 data values in celavi.data_manager.LandfillLocations.Landfill Closure Year were backfilled as -1
validating OtherFacilityLocations
validated OtherFacilityLocations
validating StandardScenarios
validated StandardScenarios
no missing data values in celavi.data_manager.StandardScenarios.wind_onshore_MW
no missing data values in celavi.data_manager.StandardScenarios.upv_MW
validating PVTechUnitChars
validated PVTechUnitChars
no missing data values in celavi.data_manager.PVTechUnitChars.year
no missing data values in celavi.data_manager.PVTechUnitChars.MWdc_per_m2
no missing data values in celavi.data_manager.PVTechUnitChars.MWdc_per_module
no missing data values in celavi.data_manager.PVTechUnitChars.glass_metrictonne_per_module
validating StateCentroids
validated StateCentroids
no missing data values in celavi.data_manager.StateCentroids.lat
no missing data values in celavi.data_manager.StateCentroids.long
Run routes completed at 1 s
CostGraph instantiation started at 1 s
CostGraph: Adding nodes and edges
CostGraph: Adding nodes and edges took 0.0 minutes
CostGraph: Calculating edge costs
CostGraph: Calculating edge costs took 0.0 minutes
CostGraph: Adjusting all costs for 2000 upwards by $4417.0
CostGraph: Instantiation took 0.0 minutes
CostGraph instantiated at 1 s
Context initialized at 2 s
Instantiating 2495.0 components at 2 s
100 components instantiated
200 components instantiated
300 components instantiated
400 components instantiated
500 components instantiated
600 components instantiated
700 components instantiated
800 components instantiated
900 components instantiated
1000 components instantiated
1100 components instantiated
1200 components instantiated
1300 components instantiated
1400 components instantiated
1500 components instantiated
1600 components instantiated
1700 components instantiated
1800 components instantiated
1900 components instantiated
2000 components instantiated
2100 components instantiated
2200 components instantiated
2300 components instantiated
2400 components instantiated
Instantiating components took 10.11 minutes
Beginning discrete event simulation at 609 s
CostGraph.update_costs: Adjusting all costs for 2001.0 upwards by $4417.0
CostGraph.update_costs: Adjusting all costs for 2002.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2002.0 after 9.1 s
CostGraph.update_costs: Adjusting all costs for 2003.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2003.0 after 7.5 s
CostGraph.update_costs: Adjusting all costs for 2004.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2004.0 after 6.1 s
CostGraph.update_costs: Adjusting all costs for 2005.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2005.0 after 10.3 s
CostGraph.update_costs: Adjusting all costs for 2006.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2006.0 after 10.1 s
CostGraph.update_costs: Adjusting all costs for 2007.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2007.0 after 6.2 s
CostGraph.update_costs: Adjusting all costs for 2008.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2008.0 after 5.7 s
CostGraph.update_costs: Adjusting all costs for 2009.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2009.0 after 7.3 s
CostGraph.update_costs: Adjusting all costs for 2010.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2010.0 after 9.4 s
CostGraph.update_costs: Adjusting all costs for 2011.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2011.0 after 8.7 s
CostGraph.update_costs: Adjusting all costs for 2012.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2012.0 after 8.5 s
CostGraph.update_costs: Adjusting all costs for 2013.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2013.0 after 9.9 s
CostGraph.update_costs: Adjusting all costs for 2014.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2014.0 after 7.4 s
CostGraph.update_costs: Adjusting all costs for 2015.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2015.0 after 6.5 s
CostGraph.update_costs: Adjusting all costs for 2016.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2016.0 after 9.8 s
CostGraph.update_costs: Adjusting all costs for 2017.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2017.0 after 13.9 s
CostGraph.update_costs: Adjusting all costs for 2018.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2018.0 after 12.2 s
CostGraph.update_costs: Adjusting all costs for 2019.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2019.0 after 16.2 s
CostGraph.update_costs: Adjusting all costs for 2020.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2020.0 after 13.6 s
CostGraph.update_costs: Adjusting all costs for 2021.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2021.0 after 13.5 s
CostGraph.update_costs: Adjusting all costs for 2022.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2022.0 after 7.6 s
CostGraph.update_costs: Adjusting all costs for 2023.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2023.0 after 19.0 s
CostGraph.update_costs: Adjusting all costs for 2024.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2024.0 after 12.2 s
CostGraph.update_costs: Adjusting all costs for 2025.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2025.0 after 11.9 s
CostGraph.update_costs: Adjusting all costs for 2026.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2026.0 after 9.6 s
CostGraph.update_costs: Adjusting all costs for 2027.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2027.0 after 21.5 s
CostGraph.update_costs: Adjusting all costs for 2028.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2028.0 after 24.9 s
CostGraph.update_costs: Adjusting all costs for 2029.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2029.0 after 32.6 s
CostGraph.update_costs: Adjusting all costs for 2030.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2030.0 after 37.0 s
CostGraph.update_costs: Adjusting all costs for 2031.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2031.0 after 1813.1 s
CostGraph.update_costs: Adjusting all costs for 2032.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2032.0 after 959.5 s
CostGraph.update_costs: Adjusting all costs for 2033.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2033.0 after 1195.4 s
CostGraph.update_costs: Adjusting all costs for 2034.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2034.0 after 879.8 s
CostGraph.update_costs: Adjusting all costs for 2035.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2035.0 after 705.0 s
CostGraph.update_costs: Adjusting all costs for 2036.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2036.0 after 932.8 s
CostGraph.update_costs: Adjusting all costs for 2037.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2037.0 after 899.4 s
CostGraph.update_costs: Adjusting all costs for 2038.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2038.0 after 939.3 s
CostGraph.update_costs: Adjusting all costs for 2039.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2039.0 after 756.4 s
CostGraph.update_costs: Adjusting all costs for 2040.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2040.0 after 960.5 s
CostGraph.update_costs: Adjusting all costs for 2041.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2041.0 after 826.9 s
CostGraph.update_costs: Adjusting all costs for 2042.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2042.0 after 742.7 s
CostGraph.update_costs: Adjusting all costs for 2043.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2043.0 after 730.4 s
CostGraph.update_costs: Adjusting all costs for 2044.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2044.0 after 665.6 s
CostGraph.update_costs: Adjusting all costs for 2045.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2045.0 after 633.0 s
CostGraph.update_costs: Adjusting all costs for 2046.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2046.0 after 688.3 s
CostGraph.update_costs: Adjusting all costs for 2047.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2047.0 after 779.6 s
CostGraph.update_costs: Adjusting all costs for 2048.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2048.0 after 625.9 s
CostGraph.update_costs: Adjusting all costs for 2049.0 upwards by $4417.0
CostGraph.update_costs: Costs updated for 2049.0 after 794.2 s
Creating diagnostic visualizations for run 0 at 17520 s
Traceback (most recent call last):
  File "C:\Users\rhanes\AppData\Local\anaconda3\envs\celavisandbox3\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\rhanes\AppData\Local\anaconda3\envs\celavisandbox3\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\rhanes\GitHub\celavi\celavi\__main__.py", line 25, in <module>
    Scenario(parser=PARSER)
  File "C:\Users\rhanes\GitHub\celavi\celavi\scenario.py", line 117, in __init__
    self.postprocess()
  File "C:\Users\rhanes\GitHub\celavi\celavi\scenario.py", line 613, in postprocess
    lcia_df = pd.read_csv(self.files["lcia_to_des"], names=lcia_names)
  File "C:\Users\rhanes\AppData\Local\anaconda3\envs\celavisandbox3\lib\site-packages\pandas\io\parsers\readers.py", line 912, in read_csv
    return _read(filepath_or_buffer, kwds)
  File "C:\Users\rhanes\AppData\Local\anaconda3\envs\celavisandbox3\lib\site-packages\pandas\io\parsers\readers.py", line 577, in _read
    parser = TextFileReader(filepath_or_buffer, **kwds)
  File "C:\Users\rhanes\AppData\Local\anaconda3\envs\celavisandbox3\lib\site-packages\pandas\io\parsers\readers.py", line 1407, in __init__
    self._engine = self._make_engine(f, self.engine)
  File "C:\Users\rhanes\AppData\Local\anaconda3\envs\celavisandbox3\lib\site-packages\pandas\io\parsers\readers.py", line 1661, in _make_engine
    self.handles = get_handle(
  File "C:\Users\rhanes\AppData\Local\anaconda3\envs\celavisandbox3\lib\site-packages\pandas\io\common.py", line 859, in get_handle
    handle = open(
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\rhanes\\GitHub\\celavi-data\\generated/final_lcia_results_to_des.csv'
```

Diagnostic results, national scale, following commits [f2d76b9](https://github.com/NREL/celavi/pull/267/commits/f2d76b92bb341639f64be4f5188d1f249ffca8f2) and [b8cc2a6](https://github.com/NREL/celavi/pull/267/commits/b8cc2a61b3fb835d2f2d20a7a9de349743125a2b) that fix the lifespan/timeout issue displayed in the above results:

These are from a national run only until 2021, in the interests of time - landfilling does not appear because no components make it all the way to landfilling during this time span.

![component_counts_0](https://github.com/user-attachments/assets/f3ebae84-0c94-444a-a8dd-53ddf5a3dc5d)

[count_cumulative_histories.csv](https://github.com/user-attachments/files/19450136/count_cumulative_histories.csv)

![material_mass_0](https://github.com/user-attachments/assets/8c9d4a07-4ffe-41e6-aba4-42c16caf209e)


Diagnostics from a 2000 - 2050 run on issue-98tiny (tiny-circfutures data):

![component_counts_0](https://github.com/user-attachments/assets/53a0cd7a-ab38-4a69-ade5-d5995a0a5631)

![material_mass_0](https://github.com/user-attachments/assets/ba1156d8-3314-43fb-b9e2-6751cc794885)

[count_cumulative_histories.csv](https://github.com/user-attachments/files/19452363/count_cumulative_histories.csv)
