### PR TITLE
Issue 286: Resolves occasional facility material flow duplication

### DIFF
--- a/celavi/des.py
+++ b/celavi/des.py
@@ -202,6 +202,10 @@ class Context:
 
         self.cost_graph = cost_graph
         self.lca = lca
+        # Adds attribute for storing each year's LCI dataframe
+        # Some values can get duplicated and reported in subsequent LCI dataframes
+        # Having this attribute lets us strip out these duplicates before they're sent for calculation
+        self.lci_last_sent = pd.DataFrame()
         self.cost_graph_update_interval_timesteps = cost_graph_update_interval_timesteps
 
         self.data_for_lci: List[Dict[str, float]] = []
@@ -441,7 +445,7 @@ class Context:
                 if len(annual_transportations[annual_transportations != 0]) == 1:
                     # Provide one row of data to LCIA by filtering out zeros/Nones. No aggregation needed.
                     if any(route_ids[annual_transportations != 0].tolist()):
-                        _route_id_list = [r for rs in route_ids[annual_transportations != 0].tolist() for r in rs]
+                        _route_id_list = ''.join([r for rs in route_ids[annual_transportations != 0].tolist() for r in rs])
                     else:
                         _route_id_list = [None]
                     row = {
@@ -489,7 +493,7 @@ class Context:
                                 "material": "transportation",
                                 "flow unit": "t * km",
                                 "facility_id": facility_id,
-                                "route_id": _r,
+                                "route_id": str(_r),
                                 "state": self.facility_states[facility_id],
                             }
                             self.data_for_lci.append(row)
@@ -501,7 +505,32 @@ class Context:
                         f"{datetime.now()} pylca_interface_process(): Found flow quantities greater than 0, performing LCIA"
                     )
                 df_for_pylca_interface = pd.DataFrame(annual_data_for_lci)
-                self.lca.pylca_run_main(df_for_pylca_interface, self.verbose)
+                # The first time these calculations are run, lci_last_sent is empty
+                # only check for and remove duplicates if there is a previous df_for_pylca_interface stored
+                # in lci_last_sent
+                if len(self.lci_last_sent) != 0:
+                    # Doing an outer merge on the last-sent LCI and the current LCI with indicator=True constructs a
+                    # data frame with all of the entries in both LCIs and a column called _merge that indicates if each
+                    # row is only in the left-hand DF (current LCI), only in the right-hand LCI (last-sent LCI), or in
+                    # both LCIs (duplicate entry!).
+                    # The query pulls out only rows that are in the current LCI (ie ignores rows in the last-sent LCI AND 
+                    # rows that appear in both), and the drop removes the _merge column
+                    df_to_lcia_calcs = pd.merge(
+                        df_for_pylca_interface, 
+                        self.lci_last_sent,
+                        indicator=True,
+                        how='outer'
+                        ).query(
+                            '_merge=="left_only"'
+                            ).drop(
+                                '_merge', axis=1
+                                )
+                    print(f"{year} LCI: {df_to_lcia_calcs}")
+                else:
+                    df_to_lcia_calcs = df_for_pylca_interface
+
+                self.lca.pylca_run_main(df_to_lcia_calcs, self.verbose)
+                self.lci_last_sent = df_to_lcia_calcs
             else:
                 if self.verbose == 1:
                   print(f"{datetime.now()} pylca_interface_process(): All Masses are 0")

--- a/celavi/pylca_celavi/des_interface.py
+++ b/celavi/pylca_celavi/des_interface.py
@@ -49,6 +49,7 @@ class PylcaCelavi:
         self.use_shortcut_lca_calculations = use_shortcut_lca_calculations
         self.verbose = verbose
         self.run = run
+        self.data_dir = data_dir
 
         # The results file should be removed if present. The LCA results are appended to the results file. 
         try:
@@ -185,6 +186,10 @@ class PylcaCelavi:
         lcia_mass_flow = pd.DataFrame()
         states = list(pd.unique(df["state"]))
 
+        #Saving the input data
+        data_sent_to_liaison = self.data_dir + "/generated/" + "data_sent_to_liaison.csv"
+        df.to_csv(data_sent_to_liaison, mode='a', header=False, index=False)
+
         # The LCA needs to be done for every region separately. Thus separating the states in the dataframe.
         for st in states:
             df_s = df[df["state"] == st]
@@ -239,6 +244,7 @@ class PylcaCelavi:
                                 unit,
                                 route_id,
                                 state,
+                                self.data_dir,
                                 self.verbose,
                                 bw
                             )

--- a/celavi/pylca_celavi/liaison/edit_activity_ecoinvent.py
+++ b/celavi/pylca_celavi/liaison/edit_activity_ecoinvent.py
@@ -145,7 +145,7 @@ def modify_electricity_grid_mix_and_solar_glass_removal(process_selected_as_fore
     return run_filename
 
 
-def module_disassembly_glass_content(process_selected_as_foreground,year_of_study,functional_unit):
+def module_disassembly_glass_content(process_selected_as_foreground,year_of_study,functional_unit,input_dir):
     """
     This function is used to convert kilograms of solar glass in module manufacturing to number of modules to square meter
     This is because Ecoinvent works with module as square meter
@@ -166,7 +166,7 @@ def module_disassembly_glass_content(process_selected_as_foreground,year_of_stud
     """
 
     
-    glass_module_df = pd.read_csv("/kfs2/projects/celavicf/celavi-master/celavi-data/inputs/glasspermodule_pvice.csv")
+    glass_module_df = pd.read_csv(input_dir+"glasspermodule_pvice.csv")
     if process_selected_as_foreground == "module disassembly":
         #Convert the function unit
         chosen_year_df = glass_module_df[glass_module_df['year'] == int(year_of_study)].reset_index()
@@ -182,7 +182,7 @@ def module_disassembly_glass_content(process_selected_as_foreground,year_of_stud
 
 
 
-def module_required_for_solar_glass(process_selected_as_foreground,year_of_study,functional_unit):
+def module_required_for_solar_glass(process_selected_as_foreground,year_of_study,functional_unit,input_dir):
     """
     This function is used to convert kilograms of solar glass in module manufacturing to number of modules to square meter
     This is because Ecoinvent works with module as square meter
@@ -201,7 +201,7 @@ def module_required_for_solar_glass(process_selected_as_foreground,year_of_study
         Modified functional unit
 
     """
-    glass_module_df = pd.read_csv("/kfs2/projects/celavicf/celavi-master/celavi-data/inputs/glasspermodule_pvice.csv")
+    glass_module_df = pd.read_csv(input_dir+"glasspermodule_pvice.csv")
     if process_selected_as_foreground['name'] == "photovoltaic panel production, multi-Si wafer":
         #Convert the function unit
         chosen_year_df = glass_module_df[glass_module_df['year'] == int(year_of_study)].reset_index()
@@ -219,7 +219,7 @@ def module_required_for_solar_glass(process_selected_as_foreground,year_of_study
         return functional_unit
 
 
-def module_installation_for_solar_glass(process_selected_as_foreground,year_of_study,functional_unit):
+def module_installation_for_solar_glass(process_selected_as_foreground,year_of_study,functional_unit,input_dir):
     """
     This function is used to convert kilograms of solar glass in module manufacturing to units of installation
     This is because Ecoinvent works with module installation as unit
@@ -238,7 +238,7 @@ def module_installation_for_solar_glass(process_selected_as_foreground,year_of_s
         Modified functional unit
 
     """
-    glass_module_df = pd.read_csv("/kfs2/projects/celavicf/celavi-master/celavi-data/inputs/glasspermodule_pvice.csv")
+    glass_module_df = pd.read_csv(input_dir+"glasspermodule_pvice.csv")
     if process_selected_as_foreground['name'] == "electric installation, 570 kWp photovoltaic plant, at plant":
         #Convert the function unit
         chosen_year_df = glass_module_df[glass_module_df['year'] == int(year_of_study)].reset_index()

--- a/celavi/pylca_celavi/liaison/liaison_model.py
+++ b/celavi/pylca_celavi/liaison/liaison_model.py
@@ -14,7 +14,7 @@ from celavi.pylca_celavi.liaison.search_activity_ecoinvent import search_activit
 from celavi.pylca_celavi.liaison.edit_activity_ecoinvent import modify_electricity_grid_mix_and_solar_glass_removal,module_required_for_solar_glass,module_installation_for_solar_glass,window_frame,landfilling_functional_unit,module_disassembly_glass_content
 
 
-def main_run(lca_project,updated_project_name,year_of_study,results_filename,mc_foreground_flag,lca_flag,region_sensitivity_flag,edit_ecoinvent_user_controlled,region,data_dir,primary_process,process_under_study,location_under_study,unit_under_study,updated_database,mc_runs,functional_unit,inventory_filename,output_dir,bw):
+def main_run(lca_project,updated_project_name,year_of_study,results_filename,mc_foreground_flag,lca_flag,region_sensitivity_flag,edit_ecoinvent_user_controlled,region,data_dir,input_dir,primary_process,process_under_study,location_under_study,unit_under_study,updated_database,mc_runs,functional_unit,inventory_filename,output_dir,bw):
 
     """
     This function defines the result arrays and then calls monte carlo analysis if required or just runs the 
@@ -132,7 +132,7 @@ def main_run(lca_project,updated_project_name,year_of_study,results_filename,mc_
                 inventory['supplying_location'] = location_under_study
                 #inventory is a dataframe
                 process_dictionary = liaison_calc(db,inventory,bw)
-                functional_unit =  module_disassembly_glass_content(process_under_study,year_of_study,functional_unit)
+                functional_unit =  module_disassembly_glass_content(process_under_study,year_of_study,functional_unit,input_dir)
 
             else:
                 inventory = searched_item  #dictionary
@@ -142,10 +142,10 @@ def main_run(lca_project,updated_project_name,year_of_study,results_filename,mc_
                     #inventory here has to be a dictionary. So if we read inventory from csv file we cannot edit it.             
                     
                     #Editing the functional unit for solar module manufacturing
-                    functional_unit = module_required_for_solar_glass(inventory,year_of_study,functional_unit)
+                    functional_unit = module_required_for_solar_glass(inventory,year_of_study,functional_unit,input_dir)
 
                     #Editing the functional unit for solar module installation
-                    functional_unit = module_installation_for_solar_glass(inventory,year_of_study,functional_unit)
+                    functional_unit = module_installation_for_solar_glass(inventory,year_of_study,functional_unit,input_dir)
 
                     # Editing the functional unit for window frame manufacturing
                     functional_unit = window_frame(inventory,year_of_study,functional_unit)
@@ -299,8 +299,8 @@ def main_run(lca_project,updated_project_name,year_of_study,results_filename,mc_
     try:
         bw.projects.delete_project(bw.projects.current, delete_dir=True) 
         print('Deleted succesfully')
-        bw.projects.purge_deleted_directories()
+        #bw.projects.purge_deleted_directories()
     except:
         print('There was an issue with deletion')
-        bw.projects.purge_deleted_directories()
+        #bw.projects.purge_deleted_directories()
 

--- a/celavi/pylca_celavi/pylca_liaison.py
+++ b/celavi/pylca_celavi/pylca_liaison.py
@@ -16,6 +16,7 @@ def liaison_lci(
     unit,
     route_id,
     state,
+    data_dir,
     verbose,
     bw
     ):
@@ -92,8 +93,8 @@ def liaison_lci(
     # Not sure why I changed state to a list and then loop through the list. Can be changed to directly storing the variable. 
     state_from_celavi = [state]
 
-    liaison_process_bridge_dir = "/kfs2/projects/celavicf/celavi-master-usa/celavi-data/inputs/"
-    liaison_process_bridge = pd.read_csv(liaison_process_bridge_dir+'liaison_process_bridge.csv')
+    input_dir = data_dir + "/inputs/"
+    liaison_process_bridge = pd.read_csv(input_dir+'liaison_process_bridge.csv')
     
 
     # This is the method of connecting with CELAVI. Not using this since we want to debug the activities
@@ -117,8 +118,8 @@ def liaison_lci(
 
         #These data directories are relevant to LiAISON. 
         #inventory_to_be_built_from_celavi = pd.read_csv('/kfs2/shared-projects/liaison/liaison_reeds/data/inputs/example.csv')
-        data_dir = "/kfs2/projects/celavicf/celavi-master-usa/celavi-data/generated/"
-        output_dir = "/kfs2/projects/celavicf/celavi-master-usa/"
+        data_dir_generated = data_dir + "/generated/"
+        output_dir = data_dir
 
         #These are two ways in which LCA can be performed. 
         #1. One where the activity is present in Ecoinvent. We need to extract it, edit it and then do LCA.
@@ -127,7 +128,7 @@ def liaison_lci(
         # Right now, the dataframe being read is empty. 
         inventory_to_be_built_from_celavi = pd.DataFrame(columns=['process', 'flow', 'value', 'unit', 'input', 'year', 'comments', 'type',
                'process_location', 'supplying_location'])
-        inventory_to_be_built_from_celavi =  liaison_process_bridge_dir+"additional_inventories"+".csv"
+        inventory_to_be_built_from_celavi =  input_dir+"additional_inventories"+".csv"
         
         # These project names match to the project names of HIPSTER and need to be added to the yaml file
         updated_project_name='Mid_Case'+str(year_from_celavi)
@@ -274,7 +275,8 @@ def liaison_lci(
                      region_sensitivity_flag=False,
                      edit_ecoinvent_user_controlled = True,
                      region=st,
-                     data_dir=data_dir,
+                     data_dir=data_dir_generated,
+                     input_dir=input_dir,
                      primary_process=process_in_ecoinvent_for_lca_from_celavi,
                      process_under_study=process_in_ecoinvent_for_lca_from_celavi, 
                      location_under_study=st,

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -65,7 +65,7 @@ class Scenario:
             )
             raise
         try:
-            self.scenario_filename = 'yaml/'+self.scenario_filename
+            self.args.scenario= 'yaml/'+self.args.scenario
             self.scenario_filename = os.path.join(self.args.data, self.args.scenario)
             with open(self.scenario_filename, "r", encoding="utf-8") as f:
                 self.scen = yaml.load(f, Loader=yaml.FullLoader)

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -53,10 +53,11 @@ class Scenario:
         self.args = parser.parse_args()
 
         # Get the configuration information as two dictionaries
+        
         try:
+            self.args.casestudy = 'yaml/'+self.args.casestudy
             with open(
-                os.path.join(self.args.data, self.args.casestudy), "r", encoding="utf-8"
-            ) as f:
+                os.path.join(self.args.data,self.args.casestudy), "r", encoding="utf-8") as f:
                 self.case = yaml.load(f, Loader=yaml.FullLoader)
         except IOError:
             print(
@@ -64,6 +65,7 @@ class Scenario:
             )
             raise
         try:
+            self.scenario_filename = 'yaml/'+self.scenario_filename
             self.scenario_filename = os.path.join(self.args.data, self.args.scenario)
             with open(self.scenario_filename, "r", encoding="utf-8") as f:
                 self.scen = yaml.load(f, Loader=yaml.FullLoader)


### PR DESCRIPTION
See testing output and development comments on original issue #286 

Spot checks on results from scenarios 255, 444, and 368 confirm the material flow duplication is largely resolved. There's one remaining, persistent instance of duplication, which is window installation in NJ in 2032 - this row appears twice in all data_sent_to_liaison.csv files checked. Based on where these rows appear in the file, they are being sent to LiAISON in subsequent batches, which is to say that the fix implemented should be removing this duplicate alongside all the others. I have no plausible theories on why this duplication persists. It's possible that the numeric material flow value is recorded as X in one LCI and X.0000000001 (or similar) in another, so the `pd.merge` doesn't register the rows as duplicates yet the data when saved to CSV the values are rounded and become equal. But if that were the case, it's not clear why this one specific material flow is duplicated and no others. So, I'm calling this fix "good enough."

A note on Transportation - The tonne-km values may appear to contain duplicates but do not; transportation is recorded for multiple route_ids between facility pairs, and the transportation for each route_id is recorded on its own line.