### PR TITLE
Storing lca_db shortcut in memory. 

### DIFF
--- a/celavi/pylca_celavi/des_interface.py
+++ b/celavi/pylca_celavi/des_interface.py
@@ -102,6 +102,15 @@ class PylcaCelavi:
         self.verbose = verbose
         self.run_id = run
 
+        #ShortcutLCA file creator
+        self.lca_database = pd.read_csv(
+                self.shortcutlca_path,
+                header=None,
+        )
+        self.lca_database.columns = ['lcia','value', 'unit','year','method','stage','state']
+
+
+
         # Set up Brightway environment variable
         os.environ["BRIGHTWAY2_DIR"] = str(self.brightway_dir)
         if self.verbose:
@@ -291,9 +300,9 @@ class PylcaCelavi:
                         res["value"] = res["value"] / quantity
                         res.drop_duplicates(inplace=True)
                         res2 = res[['lcia','value', 'unit','year','method','stage','state']]
-                        res2.to_csv(
+                        self.lca_database = pd.concat([self.lca_database,res2]).drop_duplicates()
+                        self.lca_database.to_csv(
                             self.shortcutlca_path,
-                            mode="a",
                             index=False,
                             header=False,
                         )

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -657,7 +657,7 @@ class Scenario:
         # Postprocess and save CostGraph outputs
         self.netw.save_costgraph_outputs()
         #Save lca shortcut file
-        self.lca.lca_database.to_csv(self.shortcutlca_path,index=False,header=False)
+        self.lca.lca_database.to_csv(self.files["lcia_shortcut_db"],index=False,header=False)
 
         # Join LCIA and locations computed and write the result to enable creation of
         # maps

--- a/celavi/scenario.py
+++ b/celavi/scenario.py
@@ -656,6 +656,8 @@ class Scenario:
 
         # Postprocess and save CostGraph outputs
         self.netw.save_costgraph_outputs()
+        #Save lca shortcut file
+        self.lca.lca_database.to_csv(self.shortcutlca_path,index=False,header=False)
 
         # Join LCIA and locations computed and write the result to enable creation of
         # maps


### PR DESCRIPTION
Writing them continuously and at the end.

The continuous writing helps if the code fails due to time limits. Then we can reuse the file from a point of time than lose the new lca shortcut data. Can be removed once we have confirmed that lca shortcut db is complete. 